### PR TITLE
Support system dates back to the year 1970

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -2335,7 +2335,7 @@ static int readState(char *stateFilename)
 	}
 
 	/* Hack to hide earlier bug */
-	if ((year != 1900) && (year < 1996 || year > 2100)) {
+	if ((year != 1900) && (year < 1970 || year > 2100)) {
 	    message(MESS_ERROR,
 		    "bad year %d for file %s in state file %s\n", year,
 		    argv[0], stateFilename);


### PR DESCRIPTION
The system time on Linux can be set back as far as 1970 (the epoch time).
Currently logrotate stops working correctly if the time goes before 1996.
This value (1996) appears to have been hard coded since the code was written
back in 1996. Testing and code analysis shows this can simply be modified
to 1970.