### PR TITLE
Handle subdirectory glob on FreeBSD and other BSDs

### DIFF
--- a/config.c
+++ b/config.c
@@ -680,6 +680,10 @@ int readAllConfigPaths(const char **paths)
 
 static int globerr(const char *pathname, int theerr)
 {
+    /* A missing directory is not an error, so return 0 */
+    if (theerr == ENOTDIR)
+        return 0;
+
     glob_errno = theerr;
 
     /* We want the glob operation to abort on error, so return 1 */


### PR DESCRIPTION
- On FreeBSD and possibly other systems (I've checked and found the same in man
  pages for NetBSD, OpenBSD, and DragonFly), the errfunc callback for glob will
  receive an error when trying to match a glob with a subdirectory against a
  file:
```
     If, during the search, a directory is encountered that cannot be opened
     or read and errfunc is non-NULL, glob() calls (*errfunc)(path, errno).
     This may be unintuitive: a pattern like `*/Makefile' will try to stat(2)
     `foo/Makefile' even if `foo' is not a directory, resulting in a call to
     errfunc.  The error routine can suppress this action by testing for
     ENOENT and ENOTDIR; however, the GLOB_ERR flag will still cause an imme-
     diate return when this happens.
```