### PR TITLE
Fix printing dates in debug messages

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -1073,7 +1073,7 @@ int findNeedRotating(struct logInfo *log, int logNum, int force)
 	    if (!state->doRotate) {
 	    message(MESS_DEBUG, "  log does not need rotating "
 		    "(log has been rotated at %d-%d-%d %d:%d, "
-		    "that is not week ago yet)\n", state->lastRotated.tm_year,
+		    "that is not week ago yet)\n", 1900 + state->lastRotated.tm_year,
 		    state->lastRotated.tm_mon, state->lastRotated.tm_mday,
 		    state->lastRotated.tm_hour, state->lastRotated.tm_min);
 	    }
@@ -1086,7 +1086,7 @@ int findNeedRotating(struct logInfo *log, int logNum, int force)
 	    if (!state->doRotate) {
 	    message(MESS_DEBUG, "  log does not need rotating "
 		    "(log has been rotated at %d-%d-%d %d:%d, "
-		    "that is not hour ago yet)\n", state->lastRotated.tm_year,
+		    "that is not hour ago yet)\n", 1900 + state->lastRotated.tm_year,
 		    state->lastRotated.tm_mon, state->lastRotated.tm_mday,
 		    state->lastRotated.tm_hour, state->lastRotated.tm_min);
 	    }
@@ -1099,7 +1099,7 @@ int findNeedRotating(struct logInfo *log, int logNum, int force)
 	    if (!state->doRotate) {
 	    message(MESS_DEBUG, "  log does not need rotating "
 		    "(log has been rotated at %d-%d-%d %d:%d, "
-		    "that is not day ago yet)\n", state->lastRotated.tm_year,
+		    "that is not day ago yet)\n", 1900 + state->lastRotated.tm_year,
 		    state->lastRotated.tm_mon, state->lastRotated.tm_mday,
 		    state->lastRotated.tm_hour, state->lastRotated.tm_min);
 	    }
@@ -1112,7 +1112,7 @@ int findNeedRotating(struct logInfo *log, int logNum, int force)
 	    if (!state->doRotate) {
 	    message(MESS_DEBUG, "  log does not need rotating "
 		    "(log has been rotated at %d-%d-%d %d:%d, "
-		    "that is not month ago yet)\n", state->lastRotated.tm_year,
+		    "that is not month ago yet)\n", 1900 + state->lastRotated.tm_year,
 		    state->lastRotated.tm_mon, state->lastRotated.tm_mday,
 		    state->lastRotated.tm_hour, state->lastRotated.tm_min);
 	    }
@@ -1123,7 +1123,7 @@ int findNeedRotating(struct logInfo *log, int logNum, int force)
 	    if (!state->doRotate) {
 	    message(MESS_DEBUG, "  log does not need rotating "
 		    "(log has been rotated at %d-%d-%d %d:%d, "
-		    "that is not year ago yet)\n", state->lastRotated.tm_year,
+		    "that is not year ago yet)\n", 1900 + state->lastRotated.tm_year,
 		    state->lastRotated.tm_mon, state->lastRotated.tm_mday,
 		    state->lastRotated.tm_hour, state->lastRotated.tm_min);
 	    }

--- a/logrotate.c
+++ b/logrotate.c
@@ -1074,7 +1074,7 @@ int findNeedRotating(struct logInfo *log, int logNum, int force)
 	    message(MESS_DEBUG, "  log does not need rotating "
 		    "(log has been rotated at %d-%d-%d %d:%d, "
 		    "that is not week ago yet)\n", 1900 + state->lastRotated.tm_year,
-		    state->lastRotated.tm_mon, state->lastRotated.tm_mday,
+		    1 + state->lastRotated.tm_mon, state->lastRotated.tm_mday,
 		    state->lastRotated.tm_hour, state->lastRotated.tm_min);
 	    }
 	    break;
@@ -1087,7 +1087,7 @@ int findNeedRotating(struct logInfo *log, int logNum, int force)
 	    message(MESS_DEBUG, "  log does not need rotating "
 		    "(log has been rotated at %d-%d-%d %d:%d, "
 		    "that is not hour ago yet)\n", 1900 + state->lastRotated.tm_year,
-		    state->lastRotated.tm_mon, state->lastRotated.tm_mday,
+		    1 + state->lastRotated.tm_mon, state->lastRotated.tm_mday,
 		    state->lastRotated.tm_hour, state->lastRotated.tm_min);
 	    }
 	    break;
@@ -1100,7 +1100,7 @@ int findNeedRotating(struct logInfo *log, int logNum, int force)
 	    message(MESS_DEBUG, "  log does not need rotating "
 		    "(log has been rotated at %d-%d-%d %d:%d, "
 		    "that is not day ago yet)\n", 1900 + state->lastRotated.tm_year,
-		    state->lastRotated.tm_mon, state->lastRotated.tm_mday,
+		    1 + state->lastRotated.tm_mon, state->lastRotated.tm_mday,
 		    state->lastRotated.tm_hour, state->lastRotated.tm_min);
 	    }
 	    break;
@@ -1113,7 +1113,7 @@ int findNeedRotating(struct logInfo *log, int logNum, int force)
 	    message(MESS_DEBUG, "  log does not need rotating "
 		    "(log has been rotated at %d-%d-%d %d:%d, "
 		    "that is not month ago yet)\n", 1900 + state->lastRotated.tm_year,
-		    state->lastRotated.tm_mon, state->lastRotated.tm_mday,
+		    1 + state->lastRotated.tm_mon, state->lastRotated.tm_mday,
 		    state->lastRotated.tm_hour, state->lastRotated.tm_min);
 	    }
 	    break;
@@ -1124,7 +1124,7 @@ int findNeedRotating(struct logInfo *log, int logNum, int force)
 	    message(MESS_DEBUG, "  log does not need rotating "
 		    "(log has been rotated at %d-%d-%d %d:%d, "
 		    "that is not year ago yet)\n", 1900 + state->lastRotated.tm_year,
-		    state->lastRotated.tm_mon, state->lastRotated.tm_mday,
+		    1 + state->lastRotated.tm_mon, state->lastRotated.tm_mday,
 		    state->lastRotated.tm_hour, state->lastRotated.tm_min);
 	    }
 	    break;


### PR DESCRIPTION
I currently see this, which is broken:

considering log /var/log/apache2/access_log
  log does not need rotating (log has been rotated at 116-0-4 3:10, that is not week ago yet)
