### PR TITLE
Remove or rename already existing file

### DIFF
--- a/test/test
+++ b/test/test
@@ -1814,9 +1814,36 @@ test.log.1 0 zero
 test.log.2 0 first
 EOF
 
-# check rotation with extension appended to the filename
+cleanup 72
+
+# ------------------------------- Test 72 ------------------------------------
+preptest test.log 72 2
+
+$RLR test-config.72 --force
+
+checkoutput <<EOF
+test.log 0
+test.log.1 0 zero
+test.log.2.gz 1 first
+EOF
+
+echo 'unexpected' > test.log.1.gz
+
+$RLR test-config.72 --force
+dt="$(date +%Y%m%d%H)"
+
+checkoutput <<EOF
+test.log 0
+test.log.1 0
+test.log.1.gz-$dt.backup 0 unexpected
+test.log.2.gz 1 zero
+test.log.3.gz 1 first
+EOF
+
 cleanup 100
 
+# ------------------------------- Test 100 ------------------------------------
+# check rotation with extension appended to the filename
 preptest test.log 100 1 0
 $RLR test-config.100 --force
 

--- a/test/test-config.72.in
+++ b/test/test-config.72.in
@@ -1,0 +1,7 @@
+&DIR&/test.log {
+    daily
+    rotate 3
+    compress
+    delaycompress
+    create
+}


### PR DESCRIPTION
Those files are created when logrotate is killed during compression or rotation.