### PR TITLE
Destination already exists message should be output at error level

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -1561,7 +1561,7 @@ int prerotateSingleLog(struct logInfo *log, int logNum, struct logState *state,
 			message(MESS_FATAL, "could not allocate destFile memory\n");
 		}
 		if (!stat(destFile, &fst_buf)) {
-			message(MESS_DEBUG,
+			message(MESS_ERROR,
 					"destination %s already exists, skipping rotation\n",
 					rotNames->firstRotated);
 			hasErrors = 1;


### PR DESCRIPTION
If an error like this occurs:
  destination /var/log/apport.log-201603 already exists, skipping rotation

There's no way to tell why logrotate has exited with an error. Raise the log level of this message to ERROR so that the cause of the error is available.