### PR TITLE
#28: Add a "minage" feature

### DIFF
--- a/config.c
+++ b/config.c
@@ -405,6 +405,7 @@ static void copyLogInfo(struct logInfo *to, struct logInfo *from)
     to->minsize = from->minsize;
 	to->maxsize = from->maxsize;
     to->rotateCount = from->rotateCount;
+    to->rotateMinAge = from->rotateMinAge;
     to->rotateAge = from->rotateAge;
     to->logStart = from->logStart;
     if (from->pre)
@@ -628,6 +629,7 @@ int readAllConfigPaths(const char **paths)
 		.minsize = 0,
 		.maxsize = 0,
 		.rotateCount = 0,
+                .rotateMinAge = 0,
 		.rotateAge = 0,
 		.logStart = -1,
 		.pre = NULL,
@@ -858,7 +860,7 @@ static int readConfigFile(const char *configFile, struct logInfo *defConfig)
 #endif /* MADV_DONTFORK */
 #endif /* HAVE_MADVISE */
 
-    message(MESS_DEBUG, "reading config file %s\n", configFile);
+    message(MESS_DEBUG, "Reading config file %s\n", configFile);
 
 	start = buf;
     for (start = buf; start - buf < length; start++) {
@@ -1083,6 +1085,19 @@ static int readConfigFile(const char *configFile, struct logInfo *defConfig)
 						}
 					}
 					else continue;
+                                } else if (!strcmp(key, "minage")) {
+                                        free(key);
+                                        if ((key = isolateValue
+                                                (configFile, lineNum, "minage count", &start,
+                                                &buf, length)) != NULL) {
+                                                newlog->rotateMinAge = strtoul(key, &chptr, 0);
+                                                if (*chptr || newlog->rotateMinAge < 0) {
+                                                        message(MESS_ERROR, "%s:%d bad minimum age '%s'\n",
+                                                                configFile, lineNum, start);
+                                                        RAISE_ERROR();
+                                                }
+                                        }
+                                        else continue; 
 				} else if (!strcmp(key, "maxage")) {
 					free(key);
 					if ((key = isolateValue

--- a/config.h
+++ b/config.h
@@ -23,6 +23,11 @@
 #define STATEFILE "/var/log/logrotate.status"
 #endif
 
+#if defined(__APPLE__) && defined(__MACH__)
+#define COMPRESS_COMMAND "/usr/bin/gzip"
+#define UNCOMPRESS_COMMAND "/usr/bin/gunzip"
+#endif
+
 /*
  * Default settings for Linux - leave these last.
  */

--- a/logrotate.8
+++ b/logrotate.8
@@ -315,6 +315,10 @@ When using the \fBmail\fR command, mail the about-to-expire file,
 instead of the just-rotated file (this is the default).
 
 .TP
+\fBminage\fR \fIcount\fR
+Do not rotate logs which are less than <count> days old.
+
+.TP
 \fBmaxage\fR \fIcount\fR
 Remove rotated logs older than <count> days. The age is only checked
 if the logfile is to be rotated. The files are mailed to the

--- a/logrotate.8
+++ b/logrotate.8
@@ -479,7 +479,7 @@ the name of file which is soon to be removed. See also \fBfirstaction\fR.
 \fBrotate \fIcount\fR
 Log files are rotated \fIcount\fR times before being removed or mailed to the
 address specified in a \fBmail\fR directive. If \fIcount\fR is 0, old versions
-are removed rather than rotated.
+are removed rather than rotated. Default is 0.
 
 .TP
 \fBrenamecopy\fR

--- a/logrotate.h
+++ b/logrotate.h
@@ -46,9 +46,10 @@ struct logInfo {
     enum { ROT_HOURLY, ROT_DAYS, ROT_WEEKLY, ROT_MONTHLY, ROT_YEARLY, ROT_SIZE
             } criterium;
     unsigned long long threshhold;
-	unsigned long long maxsize;
+    unsigned long long maxsize;
     unsigned long long minsize;
     int rotateCount;
+    int rotateMinAge;
     int rotateAge;
     int logStart;
     char *pre, *post, *first, *last, *preremove;

--- a/test/test
+++ b/test/test
@@ -1544,7 +1544,7 @@ $RLR test-config.61 --force -l ./logrotate.log
 
 DATESTRING=$(/bin/date +%Y-%m-%d-%H)
 
-grep "reading config file test-config.61" logrotate.log >/dev/null
+grep "Reading config file test-config.61" logrotate.log >/dev/null
 if [ $? != 0 ]; then
 	echo "There is no log output in logrotate.log"
 	exit 3

--- a/test/test
+++ b/test/test
@@ -1773,5 +1773,47 @@ EOF
 rm -rf testdir adir
 rm -rf testdir bdir
 
+cleanup 70
+
+# ------------------------------- Test 70 ------------------------------------
+# No rotation should occur because file is too young
+preptest test.log 70 2
+
+# Put in place a state file that will force a rotation
+cat > state <<EOF
+logrotate state -- version 2
+"$PWD/test.log" 2000-1-1
+EOF
+
+$RLR test-config.70
+
+checkoutput <<EOF
+test.log 0 zero
+test.log.1 0 first
+EOF
+
+cleanup 71
+
+# ------------------------------- Test 71 ------------------------------------
+# Rotation should occur because file is old
+preptest test.log 71 2
+
+# Set log modification time to some date in the past
+touch -t 200001010000 test.log
+
+# Put in place a state file that will force a rotation
+cat > state <<EOF
+logrotate state -- version 2
+"$PWD/test.log" 2000-1-1
+EOF
+
+$RLR test-config.71
+
+checkoutput <<EOF
+test.log 0
+test.log.1 0 zero
+test.log.2 0 first
+EOF
+
 cleanup
 

--- a/test/test
+++ b/test/test
@@ -566,7 +566,7 @@ fi
 
 rm error.log
 
-grep "reading config file test-config.17" logrotate.log >/dev/null
+grep "Reading config file test-config.17" logrotate.log >/dev/null
 if [ $? != 0 ]; then
 	echo "There is no log output in logrotate.log"
 	exit 3

--- a/test/test-config.70.in
+++ b/test/test-config.70.in
@@ -1,0 +1,8 @@
+create
+
+&DIR&/test.log {
+    daily
+    rotate 3
+    missingok
+    minage 5
+}

--- a/test/test-config.71.in
+++ b/test/test-config.71.in
@@ -1,0 +1,8 @@
+create
+
+&DIR&/test.log {
+    daily
+    rotate 3
+    missingok
+    minage 5
+}


### PR DESCRIPTION
This adds a `minage` directive which can be used to specify number minimum file age in days relative to current date.

It checks file modification time and only rotates file when it's old enough.

I also fixed some typos and some log message was missing `\n` at the end.
Added a bit more logging to debug mode and moved number of seconds in a day into a constant.