### PR TITLE
travis: make distcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ script:
   - make
   - make test
   - cd test && /bin/dash test && cd ..
+  - make distcheck
 branches:
   only:
     - master


### PR DESCRIPTION
run make dist on travis

i wanted to add `make distcheck`, but `make test` is already ran in previous step