### PR TITLE
Fix the download link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The logrotate utility is designed to simplify the administration of log files on
 
 The latest release is:
 
-* [logrotate-3.10.0](https://github.com/logrotate/logrotate/releases/download/3.9.2/logrotate-3.9.2.tar.gz) ([Changelog](https://github.com/logrotate/logrotate/commit/028f1cb4))
+* [logrotate-3.10.0](https://github.com/logrotate/logrotate/releases/download/3.10.0/logrotate-3.10.0.tar.gz) ([Changelog](https://github.com/logrotate/logrotate/commit/028f1cb4))
 
 Previous releases:
 

--- a/logrotate.spec.in
+++ b/logrotate.spec.in
@@ -4,7 +4,7 @@ Version: @VERSION@
 Release: 1
 License: GPL+
 Group: System Environment/Base
-Source: https://fedorahosted.org/releases/l/o/logrotate/logrotate-%{version}.tar.gz
+Source: https://github.com/logrotate/logrotate/releases/download/%{version}/logrotate-%{version}.tar.gz
 Requires: coreutils >= 5.92 libsepol libselinux popt
 BuildRequires: libselinux-devel popt-devel
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)


### PR DESCRIPTION
The link for logrotate-3.10.0 is actually for 3.9.2.
The good news is, the changelog is alright :)