### PR TITLE
test: fix reported test number when skipping test 46

### DIFF
--- a/test/test
+++ b/test/test
@@ -1216,7 +1216,7 @@ EOF
 if [ $SELINUX_TESTS = 1 ]; then
 	chcon --type=logrotate_tmp_t test.log
 else
-	echo "Skipping SELinux part of test 6"
+	echo "Skipping SELinux part of test 46"
 fi
 
 cleanup 47


### PR DESCRIPTION
When running "make test" on a system where SELinux is disabled, the
output is currently:

    ...
    Running test 45
    Running test 46
    Skipping SELinux part of test 6
    Running test 47
    Skipping SELinux test 47
    Running test 48
    ...

The test number in the message should be 46 instead of 6.