### PR TITLE
Use autoconf checks for strndup and asprintf

### DIFF
--- a/config.c
+++ b/config.c
@@ -45,7 +45,7 @@
 #include "asprintf.c"
 #endif
 
-#if !defined(asprintf) && !defined(_FORTIFY_SOURCE)
+#if !defined(HAVE_ASPRINTF) && !defined(_FORTIFY_SOURCE)
 #include <stdarg.h>
 
 int asprintf(char **string_ptr, const char *format, ...)
@@ -78,7 +78,7 @@ int asprintf(char **string_ptr, const char *format, ...)
 
 #endif
 
-#if !defined(strndup)
+#if !defined(HAVE_STRNDUP)
 char *strndup(const char *s, size_t n)
 {
        size_t nAvail;

--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,8 @@ AC_SYS_LARGEFILE
 AC_CHECK_LIB([popt],[poptParseArgvString],,
   AC_MSG_ERROR([libpopt required but not found]))
 
+AC_CHECK_FUNCS([strndup asprintf])
+
 dnl Needed for out-of-source builds
 mkdir -p test
 


### PR DESCRIPTION
The current code in config.c can provide its own implementation of
asprintf() and strndup() if not provided by the system. However, in
order to decide if they should be provided, the check done is:

 #if !defined(name_of_function)

which only works if the function is actually defined as a macro, which
is not necessarily the case.

Therefore, we replace this logic by a proper AC_CHECK_FUNCS() check in
the configure script.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>