### PR TITLE
BUG/MAJOR: config.c: re-stat() path after mkdir()

### DIFF
--- a/config.c
+++ b/config.c
@@ -318,8 +318,7 @@ static int do_mkdir(const char *path, mode_t mode, uid_t uid, gid_t gid) {
 				path, strerror(errno));
 			return -1;
 		}
-		if ((uid != sb.st_uid || gid != sb.st_gid) && 
-			chown(path, uid, gid)) {
+		if (chown(path, uid, gid)) {
 			message(MESS_ERROR, "error setting owner of %s to uid %d and gid %d: %s\n",
 				path, uid, gid, strerror(errno));
 			return -1;


### PR DESCRIPTION
If a directory is created (ie createolddir), struct sb must be updated
in order to get appropriate st_uid and st_gid.

Before:
  ./logrotate  -f /etc/logrotate.conf
  uid: 250, sb.st_uid: 250
  gid: 250, sb.st_gid: 250

After:
  ./logrotate  -f /etc/logrotate.conf
  uid: 250, sb.st_uid: 0
  gid: 250, sb.st_gid: 250