### PR TITLE
travis: build on all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: c
+
 compiler:
   - gcc
   - clang
+
 install:
   - sudo add-apt-repository ppa:dns/gnu -y
   - sudo apt-get -qq update
   - sudo apt-get -qq install libpopt-dev libselinux1-dev libacl1-dev automake dash
+
 script:
   - ./autogen.sh
   - ./configure
@@ -13,12 +16,12 @@ script:
   - make test
   - cd test && LOGROTATE=../logrotate /bin/dash test && cd ..
   - make distcheck
-branches:
-  only:
-    - master
+
 notifications:
   email:
     recipients:
       - logrotate-owner@fedoraproject.org
     on_success: always
     on_failure: always
+
+# vim:et:ts=2:sw=2


### PR DESCRIPTION
don't see reason why not build on all branches. helps to develop feature before merging to master.

i spent quite lot time figuring out why i can't make travis build on my fork until found that was the reason. this should ensure nobody else wastes their time on that :)

also added vim modelines which should assist to keep consistent indent style