### PR TITLE
travis: add matrix to build with several gcc/clang versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,106 @@
+sudo: required
+dist: precise
 language: c
 
-compiler:
-  - gcc
-  - clang
+matrix:
+  include:
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-4.4
+      env: COMPILER=gcc-4.4
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-4.5
+      env: COMPILER=gcc-4.5
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-4.6
+      env: COMPILER=gcc-4.6
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-4.7
+      env: COMPILER=gcc-4.7
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-4.8
+      env: COMPILER=gcc-4.8
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-4.9
+      env: COMPILER=gcc-4.9
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-5
+      env: COMPILER=gcc-5
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-6
+      env: COMPILER=gcc-6
+    - compiler: clang
+      addons:
+        apt:
+          packages:
+            - clang-3.4
+      env: COMPILER=clang
+    - compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.5
+          packages:
+            - clang-3.5
+      env: COMPILER=clang-3.5
+    - compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.6
+          packages:
+            - clang-3.6
+      env: COMPILER=clang-3.6
+    - compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.7
+          packages:
+            - clang-3.7
+      env: COMPILER=clang-3.7
 
 install:
   - sudo add-apt-repository ppa:dns/gnu -y
@@ -10,8 +108,9 @@ install:
   - sudo apt-get -qq install libpopt-dev libselinux1-dev libacl1-dev automake dash
 
 script:
+  - $COMPILER --version
   - ./autogen.sh
-  - ./configure
+  - ./configure CC=$COMPILER
   - make
   - make test
   - cd test && LOGROTATE=../logrotate /bin/dash test && cd ..


### PR DESCRIPTION
to notice problems with different compilers, like #60

inspired by this post:
http://genbattle.bitbucket.org/blog/2016/01/17/c++-travis-ci/