### PR TITLE
Fix test suite in combination with bash 4.4

### DIFF
--- a/test/test
+++ b/test/test
@@ -183,7 +183,7 @@ checkoutput() {
 	if [ -n "$co_compressed" ] && [ "$co_compressed" != 0 ]; then
 		contents=`gunzip -c $file`
 	else
-		contents=`cat $file`
+		contents=`cat $file | tr -d '\000'`
 	fi
 	if [ "$contents" != "$expected" ]; then
 	    echo "file $file does not contain expected results (compressed $co_compressed, args $*)" >&2


### PR DESCRIPTION
Until bash 4.4, variables weresilently striped of NUL bytes; with Bash 4.4
this results now for every single 0-byte that is being stripped in a warning:

./test: line 170: warning: command substitution: ignored null byte in input

We now simply strip the NUL bytes before we have bash assign the values to
a variable. The result is the same.