### PR TITLE
Patches that are in use within openSUSE

### DIFF
--- a/config.c
+++ b/config.c
@@ -648,6 +648,7 @@ int readAllConfigPaths(const char **paths)
 		.preremove = NULL,
 		.logAddress = NULL,
 		.extension = NULL,
+		.addextension = NULL,
 		.compress_prog = NULL,
 		.uncompress_prog = NULL,
 		.compress_ext = NULL,
@@ -1246,6 +1247,19 @@ static int readConfigFile(const char *configFile, struct logInfo *defConfig)
 
 					message(MESS_DEBUG, "extension is now %s\n",
 						newlog->extension);
+
+				} else if (!strcmp(key, "addextension")) {
+					if ((key = isolateValue
+						(configFile, lineNum, "addextension name", &start,
+							&buf, length)) != NULL) {
+						freeLogItem (addextension);
+						newlog->addextension = key;
+						key = NULL;
+					}
+					else continue;
+
+					message(MESS_DEBUG, "addextension is now %s\n",
+						newlog->addextension);
 
 				} else if (!strcmp(key, "compresscmd")) {
 					freeLogItem (compress_prog);

--- a/examples/logrotate.cron
+++ b/examples/logrotate.cron
@@ -1,8 +1,23 @@
-#!/bin/sh
+#!/bin/bash
 
-/usr/sbin/logrotate /etc/logrotate.conf
-EXITVALUE=$?
-if [ $EXITVALUE != 0 ]; then
-    /usr/bin/logger -t logrotate "ALERT exited abnormally with [$EXITVALUE]"
+# exit immediately if there is another instance running
+if pgrep /usr/sbin/logrotate > /dev/null ; then
+	/bin/logger -p cron.warning -t logrotate "ALERT another instance of logrotate is running - exiting"
+	exit 1
 fi
+
+TMPF=`mktemp ${TMPDIR:-/tmp}/logrotate.XXXXXXXXXX`
+
+/usr/sbin/logrotate /etc/logrotate.conf 2>&1 | tee $TMPF
+EXITVALUE=${PIPESTATUS[0]}
+
+if [ $EXITVALUE != 0 ]; then
+    # wait a sec, we might just have restarted syslog
+    sleep 1
+    # tell what went wrong
+    /bin/logger -p cron.warning -t logrotate "ALERT exited abnormally with [$EXITVALUE]"
+    /bin/logger -p cron.warning -t logrotate -f $TMPF
+ fi
+
+rm -f $TMPF
 exit 0

--- a/examples/logrotate.service
+++ b/examples/logrotate.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Rotate log files
+Documentation=man:logrotate(8) man:logrotate.conf(5)
+ConditionACPower=true
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/logrotate /etc/logrotate.conf
+Nice=19
+IOSchedulingClass=best-effort
+IOSchedulingPriority=7

--- a/examples/logrotate.timer
+++ b/examples/logrotate.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Daily rotation of log files
+Documentation=man:logrotate(8) man:logrotate.conf(5)
+
+[Timer]
+OnCalendar=daily
+AccuracySec=12h
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/logrotate.8
+++ b/logrotate.8
@@ -288,6 +288,15 @@ configured to be run by cron daily. You have to change this configuration
 and run \fIlogrotate\fR hourly to be able to really rotate logs hourly.
 
 .TP
+\fBaddextension \fIext\fR
+Log files are given the final extension \fIext\fR after rotation. If
+the original file already ends with \fIext\fR, the extension is not
+duplicated, but merely moved to the end, i.e. both \fBfilename\fR and
+\fBfilename\fIext\fR would get rotated to filename.1\fIext\fR. If
+compression is used, the compression extension (normally \fB.gz\fR)
+appears after \fIext\fR.
+
+.TP
 \fBifempty\fR
 Rotate the log file even if it is empty, overriding the \fBnotifempty\fR
 option (\fBifempty\fR is the default).

--- a/logrotate.8
+++ b/logrotate.8
@@ -127,6 +127,10 @@ compressed after they are rotated.  Note that comments may appear
 anywhere in the config file as long as the first non-whitespace
 character on the line is a \fB#\fR.
 
+Values are separated from directives by whitespace and/or an optional =.
+Numbers must be specified in a format understood by
+.BR strtoul(3).
+
 The next section of the config file defines how to handle the log file
 \fI/var/log/messages\fR. The log will go through five weekly rotations before
 being removed. After the log file has been rotated (but before the old

--- a/logrotate.c
+++ b/logrotate.c
@@ -1227,6 +1227,24 @@ int prerotateSingleLog(struct logInfo *log, int logNum, struct logState *state,
 
     rotNames->baseName = strdup(ourBaseName(log->files[logNum]));
 
+    if (log->addextension) {
+        size_t baseLen = strlen(rotNames->baseName);
+	size_t extLen = strlen(log->addextension);
+	if (baseLen >= extLen &&
+	    strncmp(&(rotNames->baseName[baseLen - extLen]),
+	      log->addextension, extLen) == 0) {
+	char *tempstr;
+
+	fileext = log->addextension;
+	tempstr = calloc(baseLen - extLen + 1, sizeof(char));
+	strncat(tempstr, rotNames->baseName, baseLen - extLen);
+	free(rotNames->baseName);
+	rotNames->baseName = tempstr;
+	} else {
+	    fileext = log->addextension;
+	}
+    }
+
     if (log->extension &&
 	strncmp(&
 		(rotNames->

--- a/logrotate.h
+++ b/logrotate.h
@@ -55,6 +55,7 @@ struct logInfo {
     char *pre, *post, *first, *last, *preremove;
     char *logAddress;
     char *extension;
+    char *addextension;
     char *compress_prog;
     char *uncompress_prog;
     char *compress_ext;

--- a/test/test
+++ b/test/test
@@ -1814,5 +1814,28 @@ test.log.1 0 zero
 test.log.2 0 first
 EOF
 
+# check rotation with extension appended to the filename
+cleanup 100
+
+preptest test.log 100 1 0
+$RLR test-config.100 --force
+
+checkoutput <<EOF
+test.log 0
+test.log.1.newext 0 zero
+EOF
+
+# check rotation with extension moved after the number
+cleanup 101
+
+preptest test.log 101 1 0
+$RLR test-config.101 --force
+
+checkoutput <<EOF
+test.log 0
+test.1.log 0 zero
+EOF
+
+
 cleanup
 

--- a/test/test-config.100.in
+++ b/test/test-config.100.in
@@ -1,0 +1,7 @@
+create
+
+&DIR&/test.log {
+    monthly
+    rotate 1
+    addextension .newext
+}

--- a/test/test-config.101.in
+++ b/test/test-config.101.in
@@ -1,0 +1,7 @@
+create
+
+&DIR&/test.log {
+    monthly
+    rotate 1
+    addextension .log
+}


### PR DESCRIPTION
While updating to latest logrotate I noticed that in openSUSE we carryover quite few patches and thus took it on me to push them forward :)

We also have for last 10 years patch to determine compression extension, but I am not sure how welcome that would be as it is not acompanied by uinttest:
https://build.opensuse.org/package/view_file/Base:System/logrotate/logrotate-autoext.patch?expand=1