### PR TITLE
Add --disable-dot-files as a way to skip config files starting w/ dot

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [UNRELEASED]
 
+  - Added --disable-dot-files option to skip config files starting with
+    '.' (which would normally not show up for 'ls' anyway). This allows
+    you to deactivate a config file by renaming it instead of having to
+    delete it altogether (or move it into another directory). [Philip
+    Prindeville]
+
 ## [3.10.0] - 2016-08-03
 
   - Legacy Makefile renamed to Makefile.legacy, will be removed eventually.

--- a/Makefile.legacy
+++ b/Makefile.legacy
@@ -30,6 +30,10 @@ else
 TEST_ACL=0
 endif
 
+ifeq ($(DISABLE_DOT_FILES),yes)
+CFLAGS += -DDISABLE_DOT_FILES
+endif
+
 # HP-UX using GCC
 ifeq ($(OS_NAME),HP-UX)
     ifeq ($(RPM_OPT_FLAGS),)

--- a/config.c
+++ b/config.c
@@ -368,8 +368,14 @@ static int checkFile(const char *fname)
 	char *pattern;
 
 	/* Check if fname is '.' or '..'; if so, return false */
-	if (fname[0] == '.' && (!fname[1] || (fname[1] == '.' && !fname[2])))
+	if (fname[0] == '.') {
+#ifndef DISABLE_DOT_FILES
+		if (!fname[1] || (fname[1] == '.' && !fname[2]))
+			return 0;
+#else
 		return 0;
+#endif
+	}
 
 	/* Check if fname is ending in a taboo-extension; if so, return false */
 	for (i = 0; i < tabooCount; i++) {

--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,17 @@ AS_CASE(["$with_acl"],
 AS_IF([test "$ac_cv_lib_acl_acl_get_file" = yes],
   echo "1" > ./test/test.ACL;, echo "0" > ./test/test.ACL;)
 
+AC_ARG_ENABLE([dot-files],
+   [AS_HELP_STRING([--enable-dot-files],
+     [Include configuration files starting with dot])],
+   [],
+   [enable_dot_files=yes])
+AS_CASE(["$enable_dot_files"],
+   [yes], [],
+   [no], [AC_DEFINE([DISABLE_DOT_FILES], [1],
+     [Skip configuration files whose name starts with dot])],
+   [])
+
 AC_CHECK_FUNCS([asprintf fork madvise qsort strndup strptime vfork vsyslog])
 
 AC_CONFIG_FILES([Makefile test/Makefile logrotate.spec])

--- a/logrotate.spec.in
+++ b/logrotate.spec.in
@@ -27,7 +27,7 @@ log files on your system.
 
 %build
 %configure \
-  --with-selinux
+  --with-selinux --disable-dot-files
 make %{?_smp_mflags} RPM_OPT_FLAGS="$RPM_OPT_FLAGS"
 
 %install


### PR DESCRIPTION
It's occasionally useful to disable a configuration file without
modifying it or removing it.  The easiest way to do this is usually
to rename it, as that preserves the modification date, ownership,
and SElinux context. Unfortunately, `logrotate` currently doesn't
have a naming pattern which causes it to ignore files in a config
directory.

Here we add the capability to skip files start with dot (which
parallels what `ls` does to files/directories starting with dot
as well, in the absence of the `-a` or `-A` arguments).
