### PR TITLE
changelog: update 3.11.0 links

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -396,7 +396,8 @@ All notable changes to this project will be documented in this file.
   - ignore files in included directories which end with ~, .rpmorig, or
     .rpmsave
 
-[UNRELEASED]: https://github.com/logrotate/logrotate/compare/3.10.0...master
+[UNRELEASED]: https://github.com/logrotate/logrotate/compare/3.11.0...master
+[3.11.0]: https://github.com/logrotate/logrotate/compare/3.10.0...3.11.0
 [3.10.0]: https://github.com/logrotate/logrotate/compare/3.9.2...3.10.0
  [3.9.2]: https://github.com/logrotate/logrotate/compare/r3-9-1...3.9.2
  [3.9.1]: https://github.com/logrotate/logrotate/compare/r3-9-0...r3-9-1


### PR DESCRIPTION
this should had been done before tagging 3.11.0 so that link would appear in released tarball.