### PR TITLE
use dist-xz; cleanup upload-release.sh

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,8 @@ AC_INIT([logrotate],[3.11.0])
 
 dnl foreign: Do not require AUTHORS, ChangeLog, NEWS, and README to exist
 dnl serial-tests: Do not hide standard output of our sequential test-suite
-AM_INIT_AUTOMAKE([foreign serial-tests])
+dnl dist-xz: Produce tar.xz version of the release archive
+AM_INIT_AUTOMAKE([foreign serial-tests dist-xz])
 
 AC_DEFINE(_GNU_SOURCE)
 

--- a/upload-release.sh
+++ b/upload-release.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -x
 SELF="$0"
 TAG="$1"
@@ -25,9 +25,9 @@ test -n "$TOKEN" || usage
 TAR_GZ="${NV}.tar.gz"
 test -e "$TAR_GZ" || die "$TAR_GZ does not exist"
 
-# create .tar.xz from .tar.gz
+# check that .tar.xz is prepared
 TAR_XZ="${NV}.tar.xz"
-gzip -cd "$TAR_GZ" | xz -c > "$TAR_XZ" || die "failed to write $TAR_XZ"
+test -e "$TAR_XZ" || die "$TAR_XZ does not exist"
 
 # sign the tarballs
 for file in "$TAR_GZ" "$TAR_XZ"; do


### PR DESCRIPTION
use automake to make `tar.xz` instead of converting `tar.gz`
upload-release.sh uses basisms (`<<<`, `${xx:0:3}`), update shebang