### PR TITLE
configure --with-default-mail-command-path: specify default mail command

### DIFF
--- a/config.h
+++ b/config.h
@@ -5,7 +5,9 @@
 #define ROOT_UID 0
 
 #ifdef __hpux
+#ifndef DEFAULT_MAIL_COMMAND
 #define DEFAULT_MAIL_COMMAND "/usr/bin/mailx"
+#endif
 #define COMPRESS_COMMAND "/usr/contrib/bin/gzip"
 #define UNCOMPRESS_COMMAND "/usr/contrib/bin/gunzip"
 #ifndef STATEFILE
@@ -14,11 +16,15 @@
 #endif
 
 #ifdef SunOS
+#ifndef DEFAULT_MAIL_COMMAND
 #define DEFAULT_MAIL_COMMAND "/usr/bin/mailx"
+#endif
 #endif
 
 #ifdef __NetBSD__
+#ifndef DEFAULT_MAIL_COMMAND
 #define DEFAULT_MAIL_COMMAND "/usr/bin/mail -s"
+#endif
 #define COMPRESS_COMMAND "/usr/bin/gzip"
 #define UNCOMPRESS_COMMAND "/usr/bin/gunzip"
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -64,6 +64,22 @@ AC_ARG_WITH([state-file-path],
 AC_DEFINE_UNQUOTED([STATEFILE], "$STATE_FILE_PATH")
 AC_SUBST(STATE_FILE_PATH)
 
+AC_ARG_WITH([default-mail-command],
+  AC_HELP_STRING([--with-default-mail-command=COMMAND],
+                 [default mail command (based on config.h if not given)]),
+  [
+    case "$withval" in
+      yes|no)
+        AC_MSG_ERROR([--with-default-mail-command=COMMAND requires a command to be specified])
+        ;;
+      *)
+        DEFAULT_MAIL_COMMAND="$withval"
+        AC_DEFINE_UNQUOTED([DEFAULT_MAIL_COMMAND], "$DEFAULT_MAIL_COMMAND")
+        AC_SUBST(DEFAULT_MAIL_COMMAND)
+        ;;
+    esac
+  ])
+
 AC_CHECK_FUNCS([asprintf fork madvise qsort strndup strptime vfork vsyslog])
 
 AC_CONFIG_FILES([Makefile test/Makefile logrotate.8 logrotate.spec])

--- a/logrotate.8.in
+++ b/logrotate.8.in
@@ -58,8 +58,8 @@ output logged to that file is the same as when running \fBlogrotate\fR with
 Tells \fBlogrotate\fR which command to use when mailing logs. This
 command should accept two arguments: 1) the subject of the message, and
 2) the recipient. The command must then read a message on standard input
-and mail it to the recipient. The default mail command is \fB/bin/mail
--s\fR.
+and mail it to the recipient. The default mail command is shown in the
+output from \fBlogrotate --help\fR.
 
 .TP
 \fB\-s\fR, \fB\-\-state <statefile>\fR


### PR DESCRIPTION
Add option to configure to specify the default mail command, if not given falls back to config.h as of now