### PR TITLE
Fix GCC 7 warning:

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -544,7 +544,7 @@ int createOutputFile(char *fileName, int flags, struct stat *sb, acl_type acl, i
     return fd;
 }
 
-#define DIGITS 10
+#define DIGITS 12
 
 /* unlink, but try to call shred from GNU fileutils */
 static int shred_file(int fd, char *filename, struct logInfo *log)


### PR DESCRIPTION
Fix GCC 7 warning:

logrotate.c:587:32: error: ‘%d’ directive output may be truncated
writing between 1 and 11 bytes into a region of size 9