### PR TITLE
SECURITY: createolddir: Create old directory as unprivileged user

### DIFF
--- a/logrotate.h
+++ b/logrotate.h
@@ -80,6 +80,8 @@ TAILQ_HEAD(logInfoHead, logInfo) logs;
 extern int numLogs;
 extern int debug;
 
+int switch_user(uid_t user, gid_t group);
+int switch_user_back(void);
 int readAllConfigPaths(const char **paths);
 #if !defined(asprintf) && !defined(_FORTIFY_SOURCE)
 int asprintf(char **string_ptr, const char *format, ...);


### PR DESCRIPTION
Fix insecure old directory creation.

If parent directory of olddir is writeable by an attacker (non-root),
the attacker can override mode, owner and group of arbitrary files.