### PR TITLE
Fix accident removal of rotated files

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -1573,7 +1573,7 @@ static int prerotateSingleLog(struct logInfo *log, int logNum,
 		sortGlobResult(&globResult, strlen(rotNames->dirName) + 1 + strlen(rotNames->baseName), dformat);
 	    for (glob_count = 0; glob_count < globResult.gl_pathc; glob_count++) {
 		if (!stat((globResult.gl_pathv)[glob_count], &fst_buf)) {
-		    if ((glob_count <= (globResult.gl_pathc - rotateCount))
+		    if (((globResult.gl_pathc >= rotateCount) && (glob_count <= (globResult.gl_pathc - rotateCount)))
 			|| ((log->rotateAge > 0)
 			    &&
 			    (((nowSecs - fst_buf.st_mtime) / DAY_SECONDS)


### PR DESCRIPTION
If rotateCount is more then globResult.gl_pathc (the number of already rotated files found by glob), then all those files will be deleted.
Example: we've set `rotate 7`, but in log-directory we have:
```
access.log
access.log.20170418
access.log.20170417.gz
access.log.20170416.gz
```
We expect, that after rotation we'll get:
```
access.log
access.log.20170419
access.log.20170418.gz
access.log.20170417.gz
access.log.20170416.gz
```
But for now, we'll just lose our archives:
```
access.log
access.log.20170419
```