### PR TITLE
fix unused function error when building without ACL

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -442,6 +442,7 @@ static int runScript(struct logInfo *log, char *logfn, char *script)
 	return rc;
 }
 
+#ifdef WITH_ACL
 static int is_acl_well_supported(int err)
 {
 	switch (err) {
@@ -454,6 +455,7 @@ static int is_acl_well_supported(int err)
 		return 1;
 	}
 }
+#endif /* WITH_ACL */
 
 static int createOutputFile(char *fileName, int flags, struct stat *sb,
 			    acl_type acl, int force_mode)


### PR DESCRIPTION
Since -Werror is set, building without ACL makes the then unused
is_acl_well_supported function halt the build. Guard it as it is done
with every call of it.

Signed-off-by: Bert van Hall <bert.vanhall@avionic-design.de>