### PR TITLE
configure --enable-werror can be used to re-enable -Werror

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,7 +110,7 @@ install:
 script:
   - $COMPILER --version
   - ./autogen.sh
-  - ./configure CC=$COMPILER
+  - ./configure --enable-werror CC=$COMPILER
   - make
   - make check
   - cd test && LOGROTATE=../logrotate /bin/dash test && cd ..

--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,6 @@
 # GNU General Public License for more details.
 #
 AM_CPPFLAGS = -include config.h
-AM_CFLAGS = -Wall
 sbin_PROGRAMS = logrotate
 logrotate_SOURCES = config.c log.c logrotate.c \
 		    log.h logrotate.h queue.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,7 @@
 # GNU General Public License for more details.
 #
 AM_CPPFLAGS = -include config.h
-AM_CFLAGS = -Wall -Werror
+AM_CFLAGS = -Wall
 sbin_PROGRAMS = logrotate
 logrotate_SOURCES = config.c log.c logrotate.c \
 		    log.h logrotate.h queue.h

--- a/configure.ac
+++ b/configure.ac
@@ -178,13 +178,14 @@ AC_SUBST(ROOT_UID)
 AC_CHECK_FUNCS([asprintf fork madvise qsort strndup strptime vfork vsyslog])
 AC_CONFIG_HEADERS([config.h])
 
-dnl This has to follow after AC_CHECK_FUNCS in order to keep the checks working
+AM_CFLAGS="-Wall"
 AC_ARG_ENABLE([werror],
         [AS_HELP_STRING([--enable-werror],
                 [Treat warnings as errors (default: warnings are not errors)])],
                 [enable_werror="$enableval"],
                 [enable_werror=no])
-AS_IF([test "x$enable_werror" = "xyes"], [AX_APPEND_COMPILE_FLAGS([-Werror])])
+AS_IF([test "x$enable_werror" = "xyes"], [AM_CFLAGS="$AM_CFLAGS -Werror"])
+AC_SUBST([AM_CFLAGS])
 
 AC_CONFIG_FILES([Makefile test/Makefile logrotate.8 logrotate.spec])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -178,6 +178,14 @@ AC_SUBST(ROOT_UID)
 AC_CHECK_FUNCS([asprintf fork madvise qsort strndup strptime vfork vsyslog])
 AC_CONFIG_HEADERS([config.h])
 
+dnl This has to follow after AC_CHECK_FUNCS in order to keep the checks working
+AC_ARG_ENABLE([werror],
+        [AS_HELP_STRING([--enable-werror],
+                [Treat warnings as errors (default: warnings are not errors)])],
+                [enable_werror="$enableval"],
+                [enable_werror=no])
+AS_IF([test "x$enable_werror" = "xyes"], [AX_APPEND_COMPILE_FLAGS([-Werror])])
+
 AC_CONFIG_FILES([Makefile test/Makefile logrotate.8 logrotate.spec])
 AC_OUTPUT
 


### PR DESCRIPTION
The -Werror compiler flag is no longer used by default.