### PR TITLE
config.c / manual: list taboo extensions in alphabetical order

### DIFF
--- a/config.c
+++ b/config.c
@@ -126,10 +126,22 @@ enum {
 	STATE_ERROR = 64,
 };
 
-static const char *defTabooExts[] = { ".rpmsave", ".rpmorig", "~", ",v",
-    ".disabled", ".dpkg-old", ".dpkg-dist", ".dpkg-new", ".cfsaved",
-    ".ucf-old", ".ucf-dist", ".ucf-new",
-    ".rpmnew", ".swp", ".cfsaved", ".rhn-cfg-tmp-*"
+static const char *defTabooExts[] = {
+	",v",
+	".cfsaved",
+	".disabled",
+	".dpkg-dist",
+	".dpkg-new",
+	".dpkg-old",
+	".rhn-cfg-tmp-*",
+	".rpmnew",
+	".rpmorig",
+	".rpmsave",
+	".swp",
+	".ucf-dist",
+	".ucf-new",
+	".ucf-old",
+	"~"
 };
 static int defTabooCount = sizeof(defTabooExts) / sizeof(char *);
 

--- a/logrotate.8.in
+++ b/logrotate.8.in
@@ -573,21 +573,21 @@ The current taboo extension list is changed (see the \fBinclude\fR directive
 for information on the taboo extensions). If a + precedes the list of
 extensions, the current taboo extension list is augmented, otherwise it
 is replaced. At startup, the taboo extension list 
-.IR .rpmsave ,
-.IR .rpmorig ,
-.IR ~ ,
+.IR ,v ,
+.IR .cfsaved ,
 .IR .disabled ,
-.IR .dpkg\-old ,
 .IR .dpkg\-dist ,
 .IR .dpkg\-new ,
-.IR .cfsaved ,
-.IR .ucf\-old ,
+.IR .dpkg\-old ,
+.IR .rhn\-cfg\-tmp\-* ,
+.IR .rpmnew ,
+.IR .rpmorig ,
+.IR .rpmsave ,
+.IR .swp ,
 .IR .ucf\-dist ,
 .IR .ucf\-new ,
-.IR .rpmnew ,
-.IR .swp ,
-.IR .cfsaved ,
-.IR .rhn\-cfg\-tmp\-*
+.IR .ucf\-old ,
+.IR ~
 
 .TP
 \fBtaboopat\fR [+] \fIlist\fR


### PR DESCRIPTION
Alphabetical order helps users to read what is in the list.  In config.c
horizontal list is converted to vertical to allow version control to track
each extension separately.  Vertical ordered lists are also easy to cross
check, and indeed that helped noticing manual page had missed ,v extension
that was probably added to avoid RCS files being mangled by the logrotate.

Signed-off-by: Sami Kerola <kerolasa@iki.fi>