### PR TITLE
Patches from the debian package

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [UNRELEASED]: https://github.com/logrotate/logrotate/compare/3.12.3...master
 
+  - add ```.dpkg-bak``` and ```.dpkg-del``` to default tabooext list
+
 ## [3.12.3] - 2017-06-30
 
   - ```copy``` and ```copytruncate``` directives now work together again

--- a/config.c
+++ b/config.c
@@ -130,6 +130,8 @@ static const char *defTabooExts[] = {
 	",v",
 	".cfsaved",
 	".disabled",
+	".dpkg-bak",
+	".dpkg-del",
 	".dpkg-dist",
 	".dpkg-new",
 	".dpkg-old",

--- a/logrotate.8.in
+++ b/logrotate.8.in
@@ -576,6 +576,8 @@ is replaced. At startup, the taboo extension list
 .IR ,v ,
 .IR .cfsaved ,
 .IR .disabled ,
+.IR .dpkg\-bak ,
+.IR .dpkg\-del ,
 .IR .dpkg\-dist ,
 .IR .dpkg\-new ,
 .IR .dpkg\-old ,


### PR DESCRIPTION
The logrotate package in Debian contains some patches that might make sense to include upstream:

1. Add `.dpkg-bak` and `.dpkg-del` to default taboo list https://bugs.debian.org/716649
2. Running as non-root, warn but don't abort if we can't chown the compressed log file https://bugs.debian.org/484762

> I'm running logrotate as a non-root user. Some of the log files have group mail, which logrotate tries to preserve. Since it does not have permission to do the chown (although chgrp should work AFAIK), it fails. All this would be fine, except that it then copies a length 0 file to the compressed (rotated log).

