### PR TITLE
tests: specify (un)compress utility explicitly

### DIFF
--- a/test/test-config.10.in
+++ b/test/test-config.10.in
@@ -4,6 +4,9 @@ create
     daily
     rotate 3
     compress
+    compresscmd gzip
+    uncompresscmd gunzip
+    compressext .gz
     delaycompress
     create
     mailfirst

--- a/test/test-config.11.in
+++ b/test/test-config.11.in
@@ -1,6 +1,9 @@
 create
 
 compress
+compresscmd gzip
+uncompresscmd gunzip
+compressext .gz
 
 &DIR&/test.log {
     monthly

--- a/test/test-config.55.in
+++ b/test/test-config.55.in
@@ -8,6 +8,9 @@ copytruncate
 
 # compress the file
 compress
+compresscmd gzip
+uncompresscmd gunzip
+compressext .gz
 
 # do only rotate when not empty
 notifempty

--- a/test/test-config.57.in
+++ b/test/test-config.57.in
@@ -5,6 +5,7 @@ create
     compress
     compresscmd ./compress-error
     compressoptions -f -9
+    compressext .gz
     weekly
     rotate 1
 }

--- a/test/test-config.64.in
+++ b/test/test-config.64.in
@@ -6,6 +6,9 @@ create
     dateformat -%Y%m%d
     rotate 0
     compress
+    compresscmd gzip
+    uncompresscmd gunzip
+    compressext .gz
     nosharedscripts
     dateext
     mail user@myhost.org

--- a/test/test-config.72.in
+++ b/test/test-config.72.in
@@ -2,6 +2,9 @@
     daily
     rotate 3
     compress
+    compresscmd gzip
+    uncompresscmd gunzip
+    compressext .gz
     delaycompress
     create
 }

--- a/test/test-config.8.in
+++ b/test/test-config.8.in
@@ -1,6 +1,9 @@
 create
 
 compress
+compresscmd gzip
+uncompresscmd gunzip
+compressext .gz
 
 &DIR&/test.log {
     monthly


### PR DESCRIPTION
... to prevent test failures if a custom compression utility is set
using the ```--with-compress-command```, ```--with-uncompress-command```, and
```--with-compress-extension``` build-time options.