### PR TITLE
fix spelling, found by scan-build

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -248,7 +248,7 @@ static int allocateHash(unsigned int hs)
 	}
 
 	for (i = 0; i < hs; i++) {
-		states[i] = malloc(sizeof(struct logState));
+		states[i] = malloc(sizeof(struct logStates));
 		if (states[i] == NULL) {
 			message(MESS_ERROR, "could not allocate memory for "
 				"hash element\n");


### PR DESCRIPTION
logrotate.c:251:15: warning: Result of 'malloc' is converted to a pointer of type 'struct logStates', which is incompatible with sizeof operand type 'struct logState'