### PR TITLE
writeState(): call fflush() before fsync()

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -2314,6 +2314,9 @@ static int writeState(const char *stateFilename)
 	}
 
 	if (error == 0)
+		error = fflush(f);
+
+	if (error == 0)
 		error = fsync(fdsave);
 
 	if (error == 0)


### PR DESCRIPTION
Flush the libc buffers before calling fsync().

Otherwise the file content may not yet have been written to the kernel,
and fsync() will not help in ensuring that the file data is written to
disk.