### PR TITLE
Updated DEFAULT_MAIL_COMMAND in configure.ac and updated man page

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -71,7 +71,7 @@ case "$host" in
           DEFAULT_MAIL_COMMAND="/usr/bin/mailx"
           ;;
   *-netbsd*)
-          DEFAULT_MAIL_COMMAND="/usr/bin/mail -s"
+          DEFAULT_MAIL_COMMAND="/usr/bin/mail"
           COMPRESS_COMMAND="/usr/bin/gzip"
           UNCOMPRESS_COMMAND="/usr/bin/gunzip"
           ;;
@@ -99,7 +99,7 @@ AC_SUBST(STATE_FILE_PATH)
 
 AC_ARG_WITH([default-mail-command],
   AC_HELP_STRING([--with-default-mail-command=COMMAND],
-                 [default mail command (e.g. /bin/mail -s)]),
+                 [default mail command (e.g. /bin/mail)]),
   [
     case "$withval" in
       yes|no)

--- a/logrotate.8.in
+++ b/logrotate.8.in
@@ -63,9 +63,9 @@ output logged to that file is the same as when running \fBlogrotate\fR with
 .TP
 \fB\-m\fR, \fB\-\-mail\fR \fIcommand\fR
 Tells \fBlogrotate\fR which command to use when mailing logs. This
-command should accept two arguments:
+command should accept the following arguments:
 .IP
-1) the subject of the message
+1) the subject of the message given with '-s subject'
 .br
 2) the recipient.
 .IP


### PR DESCRIPTION
As discussed in #150,

This PR contains 2 commits:
  - a commit that removes `-s` from `DEFAULT_MAIL_COMMAND` definition and help string in `configure.ac`
  - a commit that tentatively rephrases the `logrotate.8.in` man page template