### PR TITLE
add hourago option

### DIFF
--- a/config.c
+++ b/config.c
@@ -1063,6 +1063,8 @@ static int readConfigFile(const char *configFile, struct logInfo *defConfig)
 					newlog->flags &= ~LOG_FLAG_DATEEXT;
 				} else if (!strcmp(key, "dateyesterday")) {
 					newlog->flags |= LOG_FLAG_DATEYESTERDAY;
+				} else if (!strcmp(key, "datehourago")) {
+					newlog->flags |= LOG_FLAG_DATEHOURAGO;
 				} else if (!strcmp(key, "dateformat")) {
 					freeLogItem(dateformat);
 					newlog->dateformat = isolateLine(&start, &buf, length);

--- a/logrotate.8.in
+++ b/logrotate.8.in
@@ -282,6 +282,12 @@ extension, so that the rotated log file has a date in its name that is
 the same as the timestamps within it.
 
 .TP
+\fBdatehourago\fR
+Use hour ago instead of current date to create the \fBdateext\fR extension,
+so that the rotated log file has a hour in its name that is the same as the timestamps within it.
+Useful with rotate \fBhourly\fR
+
+.TP
 \fBdelaycompress\fR
 Postpone compression of the previous log file to the next rotation cycle.
 This only has effect when used in combination with \fBcompress\fR.

--- a/logrotate.c
+++ b/logrotate.c
@@ -1436,6 +1436,11 @@ static int prerotateSingleLog(struct logInfo *log, int logNum,
         mktime(&now);
     }
 
+    if (log->flags & LOG_FLAG_DATEHOURAGO) {
+        now.tm_hour -= 1;
+        mktime(&now);
+    }
+
 	/* Allow only %Y %d %m and create valid strftime format string
 	 * Construct the glob pattern corresponding to the date format */
 	dext_str[0] = '\0';

--- a/logrotate.h
+++ b/logrotate.h
@@ -25,6 +25,7 @@
 #define LOG_FLAG_DATEYESTERDAY	(1 << 12)
 #define LOG_FLAG_OLDDIRCREATE	(1 << 13)
 #define LOG_FLAG_TMPFILENAME	(1 << 14)
+#define LOG_FLAG_DATEHOURAGO	(1 << 15)
 
 #define NO_MODE ((mode_t) -1)
 #define NO_UID  ((uid_t) -1)


### PR DESCRIPTION
Add datehourago option that is similar to dateyesterday, but useful with hourly rotate logs.
I fixes filenames after rotate, that match do hour in file