### PR TITLE
added .dpkg-tmp to defTabooExts

### DIFF
--- a/config.c
+++ b/config.c
@@ -135,6 +135,7 @@ static const char *defTabooExts[] = {
 	".dpkg-dist",
 	".dpkg-new",
 	".dpkg-old",
+	".dpkg-tmp",
 	".rhn-cfg-tmp-*",
 	".rpmnew",
 	".rpmorig",


### PR DESCRIPTION
As we have issues running logrotate during package upgrades:
reading config file project-api
reading config file project-api.dpkg-tmp
error: project-api.dpkg-tmp:1 duplicate log entry for /var/log/project/api.log