### PR TITLE
Move wtmp/btmp definitions to logrotate.d

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [UNRELEASED]
 
-[UNRELEASED]: https://github.com/logrotate/logrotate/compare/3.13.0...master
+[UNRELEASED]: https://github.com/logrotate/logrotate/compare/3.13.1...master
+
+## [3.13.1] - 2018-01-31
+
+  - move ```wtmp``` and ```btmp``` definitions to ```logrotate.d```
 
 ## [3.13.0] - 2017-10-13
 

--- a/README.HPUX
+++ b/README.HPUX
@@ -9,7 +9,7 @@ also work on HP-UX 10.20):
     at http://hpux.cs.utah.edu/.
 
     Obtain and install the following GNU/Linux to HP-UX Porting package:
-	libhplx library
+    libhplx library
     See http://devresource.hp.com/LPK/index.html for downloads.
     This library is needed to provide the ??? function.
  
@@ -29,7 +29,8 @@ also work on HP-UX 10.20):
  
 5.  Copy the configuration files into your desired location.
         cp examples/logrotate-default /etc/logrotate.conf
-	mkdir /etc/logrotate.d
+        mkdir /etc/logrotate.d
+        cp examples/?tmp /etc/logrotate.d
 
 6.  Set up a cron job to run logrotate daily. See examples/logrotate.cron.
  

--- a/examples/btmp
+++ b/examples/btmp
@@ -1,0 +1,7 @@
+# no packages own wtmp and btmp -- we'll rotate them here
+/var/log/btmp {
+    missingok
+    monthly
+    create 0600 root utmp
+    rotate 1
+}

--- a/examples/logrotate-default
+++ b/examples/logrotate-default
@@ -17,20 +17,4 @@ dateext
 # RPM packages drop log rotation information into this directory
 include /etc/logrotate.d
 
-# no packages own wtmp and btmp -- we'll rotate them here
-/var/log/wtmp {
-    missingok
-    monthly
-    create 0664 root utmp
-    minsize 1M
-    rotate 1
-}
-
-/var/log/btmp {
-    missingok
-    monthly
-    create 0600 root utmp
-    rotate 1
-}
-
 # system-specific logs may be also be configured here.

--- a/examples/wtmp
+++ b/examples/wtmp
@@ -1,0 +1,8 @@
+# no packages own wtmp and btmp -- we'll rotate them here
+/var/log/wtmp {
+    missingok
+    monthly
+    create 0664 root utmp
+    minsize 1M
+    rotate 1
+}

--- a/logrotate.spec.in
+++ b/logrotate.spec.in
@@ -38,6 +38,8 @@ mkdir -p $RPM_BUILD_ROOT/%{_sysconfdir}/cron.daily
 mkdir -p $RPM_BUILD_ROOT/%{_localstatedir}/lib
 
 install -p -m 644 examples/logrotate-default $RPM_BUILD_ROOT/%{_sysconfdir}/logrotate.conf
+install -p -m 644 examples/btmp $RPM_BUILD_ROOT/%{_sysconfdir}/logrotate.d/btmp
+install -p -m 644 examples/wtmp $RPM_BUILD_ROOT/%{_sysconfdir}/logrotate.d/wtmp
 install -p -m 755 examples/logrotate.cron $RPM_BUILD_ROOT/%{_sysconfdir}/cron.daily/logrotate
 touch $RPM_BUILD_ROOT/%{_localstatedir}/lib/logrotate.status
 


### PR DESCRIPTION
The definitions for wtmp and btmp, when included in the main config
file, make it very difficult to manage with CM tools
(e.g. Ansible). It would require complex logic to parse blocks within
the global file.

This patch moves them to logrotate.d directory, where they follow the
same logic as any other include from various packages, and can be easily
manipulated on per-line basis.