### PR TITLE
logrotate -d: print a warning about logrotate doing nothing

### DIFF
--- a/logrotate.8.in
+++ b/logrotate.8.in
@@ -43,8 +43,8 @@ Prints help message.
 
 .TP
 \fB\-d\fR, \fB\-\-debug\fR
-Turns on debug mode and implies \fB-v\fR.  In debug mode, no changes will
-be made to the logs or to the \fBlogrotate\fR state file.
+Turn on debug mode, which means that no changes are made to the logs and the
+\fBlogrotate\fR state file is not updated.  Only debug messages are printed.
 
 .TP
 \fB\-f\fR, \fB\-\-force\fR

--- a/logrotate.c
+++ b/logrotate.c
@@ -2592,7 +2592,7 @@ int main(int argc, const char **argv)
 
     struct poptOption options[] = {
     	{"debug", 'd', 0, NULL, 'd',
-	 "Don't do anything, just test (implies -v)", NULL},
+	 "Don't do anything, just test and print debug messages", NULL},
 	{"force", 'f', 0, &force, 0, "Force file rotation", NULL},
 	{"mail", 'm', POPT_ARG_STRING, &mailCommand, 0,
 	 "Command to send mail (instead of `" DEFAULT_MAIL_COMMAND "')",
@@ -2618,6 +2618,9 @@ int main(int argc, const char **argv)
 	switch (arg) {
 	case 'd':
 	    debug = 1;
+	    message(MESS_NORMAL, "WARNING: logrotate in debug mode does nothing"
+		    " except printing debug messages!  Consider using verbose"
+		    " mode (-v) instead if this is not what you want.\n\n");
 	    /* fallthrough */
 	case 'v':
 	    logSetLevel(MESS_DEBUG);


### PR DESCRIPTION
... and reformulate the documentation of -d to be clear in this.

Closes #165