### PR TITLE
drop popt dependency in favor of getopt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,7 @@ matrix:
 install:
   - sudo add-apt-repository ppa:dns/gnu -y
   - sudo apt-get -qq update
-  - sudo apt-get -qq install libpopt-dev libselinux1-dev libacl1-dev automake dash rpm
+  - sudo apt-get -qq install libselinux1-dev libacl1-dev automake dash rpm
 
 script:
   - $COMPILER --version

--- a/README.HPUX
+++ b/README.HPUX
@@ -13,28 +13,22 @@ also work on HP-UX 10.20):
     See http://devresource.hp.com/LPK/index.html for downloads.
     This library is needed to provide the ??? function.
  
-2.  Obtain, build, and install popt 1.4 (there doesn't seem to be a build at
-    the Porting Centre.)
-    See ftp://ftp.rpm.org/pub/rpm/dist/rpm-4.0.x/popt-1.6.4.tar.gz
-    Install it into the directory of your choice (i.e. 
-    "./configure --prefix=/opt/popt").
+2.  Build logrotate, telling it where to find hplx installation. The
+    HPLX_DIR defaults to /usr/local/hplx:
+        gmake HPLX_DIR=/usr/local/hplx
  
-3.  Build logrotate, telling it where to find popt and hplx installation. The
-    POPT_DIR defaults to /usr/local and HPLX_DIR defaults to /usr/local/hplx:
-        gmake POPT_DIR=/usr/local HPLX_DIR=/usr/local/hplx
- 
-4.  Install logrotate into your desired directory (BASEDIR defaults to
+3.  Install logrotate into your desired directory (BASEDIR defaults to
     /usr/local):
         gmake install BASEDIR=/usr/local
  
-5.  Copy the configuration files into your desired location.
+4.  Copy the configuration files into your desired location.
         cp examples/logrotate-default /etc/logrotate.conf
         mkdir /etc/logrotate.d
         cp examples/?tmp /etc/logrotate.d
 
-6.  Set up a cron job to run logrotate daily. See examples/logrotate.cron.
+5.  Set up a cron job to run logrotate daily. See examples/logrotate.cron.
  
-7.  I also recommend setting CLEAN_ADM=0 in /etc/rc.config.d/clean, and
+6.  I also recommend setting CLEAN_ADM=0 in /etc/rc.config.d/clean, and
     setting up an init script to use logrotate for this instead.  This way,
     logrotate manages all logfile pruning.
  

--- a/README.Solaris
+++ b/README.Solaris
@@ -3,7 +3,6 @@ Steps to build and install logrotate on Solaris 2.6
 1.  Obtain and install the following GNU packages from http://Sunfreeware.com:
         gcc 2.95.2
         make 3.80
-	popt-1.6.3
 
 2.  Build and install logrotate:
 	gmake

--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ Obtain source either by [Downloading](#download) it or doing [Git checkout](#git
 Install dependencies for Debian systems:
 ```
 apt-get update
-apt-get install autoconf automake libpopt-dev libtool make xz-utils
+apt-get install autoconf automake libtool make xz-utils
 ```
 
 Install dependencies for Fedora/CentOS systems:
 
 ```
-yum install autoconf automake libtool make popt-devel xz
+yum install autoconf automake libtool make xz
 ```
 
 Compilation (`autoreconf` is optional if you obtained source from tarball):

--- a/configure.ac
+++ b/configure.ac
@@ -23,10 +23,7 @@ dnl Use 64-bit file offsets on 32-bit systems (defines C macros if necessary)
 AC_SYS_LARGEFILE
 
 dnl needed for basename() on OS X
-AC_CHECK_HEADERS([libgen.h])
-
-AC_CHECK_LIB([popt],[poptParseArgvString],,
-  AC_MSG_ERROR([libpopt required but not found]))
+AC_CHECK_HEADERS([libgen.h getopt.h])
 
 dnl Needed for out-of-source builds
 mkdir -p test

--- a/logrotate.h
+++ b/logrotate.h
@@ -88,6 +88,7 @@ extern int debug;
 
 int switch_user(uid_t user, gid_t group);
 int switch_user_back(void);
+int parse_argv_string(const char *s, int *argcPtr, const char ***argvPtr);
 int readAllConfigPaths(const char **paths);
 #if !defined(asprintf) && !defined(_FORTIFY_SOURCE)
 int asprintf(char **string_ptr, const char *format, ...);

--- a/logrotate.spec.in
+++ b/logrotate.spec.in
@@ -5,8 +5,8 @@ Release: 1%{?dist}
 License: GPLv2+
 Group: System Environment/Base
 Source: https://github.com/logrotate/logrotate/releases/download/%{version}/logrotate-%{version}.tar.gz
-Requires: coreutils >= 5.92 libsepol libselinux popt
-BuildRequires: libselinux-devel popt-devel
+Requires: coreutils >= 5.92 libsepol libselinux
+BuildRequires: libselinux-devel
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 %{!?_licensedir:%global license %%doc}


### PR DESCRIPTION
**Not quite merge ready**

Removing libpopt dependency by importing from libpopt and re-implementing with getopt.

The command line parsing is re-implemented with getopt and should be roughly the same. Some differences are the error messages in cases of wrong parameters names or missing required arguments. Also `-h` is now an alias for `--help` and `-U` for `--usage`.

Two functions, `poptParseArgvString` and `poptDupArgv`, are needed for handling custom compress options. These two functions are copied and adapted for logrotate. I am not sure how handle the license matter correct for this case maybe someone could comment.

Are you willing to merge such kind of change? If yes I'll give it a deeper try and dig into the licensing question.

(The intention is to get rid of libpopt as it seems quite unmaintained.)

