### PR TITLE
return non-zero exit status if a config file contains an error

### DIFF
--- a/config.c
+++ b/config.c
@@ -1824,6 +1824,7 @@ static int readConfigFile(const char *configFile, struct logInfo *defConfig)
 			message(MESS_ERROR, "found error in %s, skipping\n",
 				newlog->pattern ? newlog->pattern : "log config");
 
+			logerror = 1;
 			state = STATE_SKIP_CONFIG;
 			break;
 		case STATE_LOAD_SCRIPT:

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -80,6 +80,7 @@ TEST_CASES = \
 	test-0079.sh \
 	test-0080.sh \
 	test-0081.sh \
+	test-0083.sh \
 	test-0100.sh \
 	test-0101.sh
 

--- a/test/test-0083.sh
+++ b/test/test-0083.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+. ./test-common.sh
+
+cleanup 83
+
+# ------------------------------- Test 83 ------------------------------------
+preptest test.log 83 1
+
+if $RLR test-config.83 -v --force; then
+    exit 1
+else
+    exit 0
+fi

--- a/test/test-config.83.in
+++ b/test/test-config.83.in
@@ -1,0 +1,3 @@
+&DIR&/test.log {
+    rotate 1 # invalid comment
+}


### PR DESCRIPTION
... which causes the config file to be skipped

Closes #199