### PR TITLE
preserve fractional part of timestamps when compressing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -166,7 +166,7 @@ AC_SUBST(COMPRESS_EXT)
 AC_DEFINE_UNQUOTED([ROOT_UID], [0], [Root user-id.])
 AC_SUBST(ROOT_UID)
 
-AC_CHECK_FUNCS([asprintf fork madvise qsort strndup strptime vfork vsyslog])
+AC_CHECK_FUNCS([asprintf fork madvise qsort strndup strptime utimensat vfork vsyslog])
 AC_CONFIG_HEADERS([config.h])
 
 AM_CFLAGS="-Wall -Wextra -Wmissing-format-attribute -Wmissing-noreturn -Wpointer-arith -Wshadow -Wstrict-prototypes -Wundef -Wunused -Wwrite-strings"


### PR DESCRIPTION
When the system clock is carefully steered by NTP (in a way that it
never jumps), one can rely on no log file containing a timestamp newer
than the mtime of the file. However, with subsecond-precision
timestamps, that property is violated when using utime() to copy the
timestamps from the original log file to the compressed version.

utimensat() should be available on most modern systems (given that it
was standardized 10 years ago), but just in case, keep a fallback to
utime().