### PR TITLE
Service unit: only run if /var/log is mounted and timer trigger fuzz from 12h to 1h

### DIFF
--- a/examples/logrotate.service
+++ b/examples/logrotate.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Rotate log files
 Documentation=man:logrotate(8) man:logrotate.conf(5)
+RequiresMountsFor=/var/log
 ConditionACPower=true
 
 [Service]

--- a/examples/logrotate.timer
+++ b/examples/logrotate.timer
@@ -4,7 +4,7 @@ Documentation=man:logrotate(8) man:logrotate.conf(5)
 
 [Timer]
 OnCalendar=daily
-AccuracySec=12h
+AccuracySec=1h
 Persistent=true
 
 [Install]


### PR DESCRIPTION
Given that `Persistent=true` can cause a timer to fire during the boot of the system if the timer would have expired while the system was shut off, the service should ensure that `/var/log` is mounted (could be a network filesystem).