### PR TITLE
Mitigation of a race condition in createOutputFile()

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -481,11 +481,32 @@ static int createOutputFile(char *fileName, int flags, struct stat *sb,
     struct stat sb_create;
     int acl_set = 0;
     int i;
+    struct stat sb_linkcheck;
+    char *dirName;
 
     for (i = 0; i < 2; ++i) {
         struct tm now;
         size_t fileName_size, buf_size;
         char *backupName, *ptr;
+
+        if(fileName == NULL)
+        {
+            message(MESS_ERROR, "filename %s must not be NULL\n ", fileName);
+            return -1;
+        }
+
+        dirName = dirname(fileName);
+
+        if(lstat(dirName,&sb_linkcheck) != 0) {
+            message(MESS_ERROR, "stat of %s failed: %s\n", dirName,
+                strerror(errno));
+            return -1;
+        }
+
+        if(S_ISLNK(sb_linkcheck.st_mode)) {
+            message(MESS_ERROR, "parent directory %s must not be a symbolik link\n", dirName);
+            return -1;
+        }
 
         fd = open(fileName, (flags | O_EXCL | O_NOFOLLOW),
                 (S_IRUSR | S_IWUSR) & sb->st_mode);


### PR DESCRIPTION
If the "create"-option is set, there is a time window between rotating the logfile
and creating/touching a new empty file. If a user is in control of the parent
directory, he/she could replace it during this time window with a symbolic link to
any directory. If logrotate was executed by root, the new file will be created first
with permissions of root and then the ownerships will be set to the user. After the
file was created, the user might be able to write any content to this file.