### PR TITLE
logrotate.8: encourage admins to use the `su` directive

### DIFF
--- a/logrotate.8.in
+++ b/logrotate.8.in
@@ -584,7 +584,9 @@ user/group (usually root). \fIuser\fR specifies the user name used for
 rotation and \fIgroup\fR specifies the group used for rotation. If the
 user/group you specify here does not have sufficient privilege to make 
 files with the ownership you've specified in a \fIcreate\fR instruction, 
-it will cause an error.
+it will cause an error.  If logrotate runs with root privileges, it is
+recommended to use the \fBsu\fR directive to rotate files in directories
+that are directly or indirectly in control of non-privileged users.
 
 .TP
 \fBtabooext\fR [+] \fIlist\fR


### PR DESCRIPTION
... to rotate files in directories that are directly or indirectly in control of non-privileged users.  Originally reported in the following pull request: https://github.com/logrotate/logrotate/pull/235