### PR TITLE
improved error messages

### DIFF
--- a/log.c
+++ b/log.c
@@ -55,9 +55,27 @@ static void log_once(FILE *where, int level, const char *format, va_list args)
 }
 
 __attribute__((format (printf, 2, 3)))
-void message(int level, const char *format, ...)
+void message(int level, char *format, ...)
 {
     va_list args;
+    switch (level) {
+        case MESS_DEBUG:
+            sprintf(format, "debug: %s", format) 
+            break;
+        case MESS_NORMAL:
+            break;
+        case MESS_VERBOSE:
+            sprintf(format, "verbose: %s", format)
+            break;
+        case MESS_ERROR:
+            sprintf(format, "error: %s", format) 
+            break;
+        case MESS_FATAL:
+            sprintf(format, "fatal: %s", format) 
+            break;
+        default:
+            break;
+    }
 
     if (level >= logLevel) {
         va_start(args, format);
@@ -101,8 +119,9 @@ void message(int level, const char *format, ...)
     }
 #endif
 
-    if (level == MESS_FATAL)
+    if (level == MESS_FATAL) {
         exit(1);
+    }
 }
 
 /* vim: set et sw=4 ts=4: */

--- a/log.c
+++ b/log.c
@@ -40,43 +40,36 @@ void logToSyslog(int enable) {
 __attribute__((format (printf, 3, 0)))
 static void log_once(FILE *where, int level, const char *format, va_list args)
 {
-    switch (level) {
-        case MESS_DEBUG:
-        case MESS_NORMAL:
-        case MESS_VERBOSE:
-            break;
-        default:
-            fprintf(where, "error: ");
-            break;
+    int size = 512;
+    char *decorated_format = (char *)malloc(sizeof(char) * size);
+    switch (level)
+    {
+    case MESS_DEBUG:
+        sprintf(decorated_format, "debug: %s", format);
+        break;
+    case MESS_NORMAL:
+        break;
+    case MESS_VERBOSE:
+        sprintf(decorated_format, "verbose: %s", format);
+        break;
+    case MESS_ERROR:
+        sprintf(decorated_format, "error: %s", format);
+        break;
+    case MESS_FATAL:
+        sprintf(decorated_format, "fatal: %s", format);
+        break;
+    default:
+        break;
     }
 
-    vfprintf(where, format, args);
+    vfprintf(where, decorated_format, args);
     fflush(where);
 }
 
 __attribute__((format (printf, 2, 3)))
-void message(int level, char *format, ...)
+void message(int level, const char *format, ...)
 {
     va_list args;
-    switch (level) {
-        case MESS_DEBUG:
-            sprintf(format, "debug: %s", format);
-            break;
-        case MESS_NORMAL:
-            break;
-        case MESS_VERBOSE:
-            sprintf(format, "verbose: %s", format);
-            break;
-        case MESS_ERROR:
-            sprintf(format, "error: %s", format);
-            break;
-        case MESS_FATAL:
-            sprintf(format, "fatal: %s", format);
-            break;
-        default:
-            break;
-    }
-
     if (level >= logLevel) {
         va_start(args, format);
         log_once(stderr, level, format, args);

--- a/log.c
+++ b/log.c
@@ -60,18 +60,18 @@ void message(int level, char *format, ...)
     va_list args;
     switch (level) {
         case MESS_DEBUG:
-            sprintf(format, "debug: %s", format) 
+            sprintf(format, "debug: %s", format);
             break;
         case MESS_NORMAL:
             break;
         case MESS_VERBOSE:
-            sprintf(format, "verbose: %s", format)
+            sprintf(format, "verbose: %s", format);
             break;
         case MESS_ERROR:
-            sprintf(format, "error: %s", format) 
+            sprintf(format, "error: %s", format);
             break;
         case MESS_FATAL:
-            sprintf(format, "fatal: %s", format) 
+            sprintf(format, "fatal: %s", format);
             break;
         default:
             break;

--- a/log.c
+++ b/log.c
@@ -40,29 +40,29 @@ void logToSyslog(int enable) {
 __attribute__((format (printf, 3, 0)))
 static void log_once(FILE *where, int level, const char *format, va_list args)
 {
-    int size = 512;
-    char *decorated_format = (char *)malloc(sizeof(char) * size);
     switch (level)
     {
     case MESS_DEBUG:
-        sprintf(decorated_format, "debug: %s", format);
+        fprintf(where, "debug: ");
         break;
     case MESS_NORMAL:
+        fprintf(where, "info: ");
         break;
     case MESS_VERBOSE:
-        sprintf(decorated_format, "verbose: %s", format);
+        fprintf(where, "verbose: ");
         break;
     case MESS_ERROR:
-        sprintf(decorated_format, "error: %s", format);
+        fprintf(where, "error: ");
         break;
     case MESS_FATAL:
-        sprintf(decorated_format, "fatal: %s", format);
+        fprintf(where, "fatal: ");
         break;
     default:
+        fprintf(where, "unknown: ");
         break;
     }
 
-    vfprintf(where, decorated_format, args);
+    vfprintf(where, format, args);
     fflush(where);
 }
 

--- a/logrotate.c
+++ b/logrotate.c
@@ -1530,7 +1530,7 @@ static int prerotateSingleLog(struct logInfo *log, int logNum,
         while ((*dext != '\0') && (!hasErrors)) {
             /* Will there be a space for a char and '\0'? */
             if (j >= (sizeof(dext_pattern) - 1)) {
-                message(MESS_ERROR, "error: Date format %s is too long\n",
+                message(MESS_ERROR, "Date format %s is too long\n",
                         log->dateformat);
                 hasErrors = 1;
                 break;
@@ -1552,7 +1552,7 @@ static int prerotateSingleLog(struct logInfo *log, int logNum,
                                 sizeof(dext_pattern) - strlen(dext_pattern) - 1);
                         j += 10;
                         if (j >= (sizeof(dext_pattern) - 1)) {
-                            message(MESS_ERROR, "error: Date format %s is too long\n",
+                            message(MESS_ERROR, "Date format %s is too long\n",
                                     log->dateformat);
                             hasErrors = 1;
                             break;
@@ -1567,7 +1567,7 @@ static int prerotateSingleLog(struct logInfo *log, int logNum,
                                 sizeof(dext_pattern) - strlen(dext_pattern) - 1);
                         j += 50;
                         if (j >= (sizeof(dext_pattern) - 1)) {
-                            message(MESS_ERROR, "error: Date format %s is too long\n",
+                            message(MESS_ERROR, "Date format %s is too long\n",
                                     log->dateformat);
                             hasErrors = 1;
                             break;
@@ -1831,7 +1831,7 @@ static int prerotateSingleLog(struct logInfo *log, int logNum,
         }
         if (!stat(destFile, &fst_buf)) {
             message(MESS_ERROR,
-                    "error: destination %s already exists, skipping rotation\n",
+                    "destination %s already exists, skipping rotation\n",
                     rotNames->firstRotated);
             hasErrors = 1;
         }
@@ -1886,7 +1886,7 @@ static int rotateSingleLog(struct logInfo *log, int logNum,
 #endif /* WITH_ACL */
             if (log->flags & LOG_FLAG_TMPFILENAME) {
                 if (asprintf(&tmpFilename, "%s%s", log->files[logNum], ".tmp") < 0) {
-                    message(MESS_FATAL, "error: could not allocate tmpFilename memory\n");
+                    message(MESS_FATAL, "could not allocate tmpFilename memory\n");
                     restoreSecCtx(&savedContext);
                     return 1;
                 }
@@ -1894,7 +1894,7 @@ static int rotateSingleLog(struct logInfo *log, int logNum,
                 message(MESS_DEBUG, "renaming %s to %s\n", log->files[logNum],
                         tmpFilename);
                 if (!debug && !hasErrors && rename(log->files[logNum], tmpFilename)) {
-                    message(MESS_ERROR, "error: failed to rename %s to %s: %s\n",
+                    message(MESS_ERROR, "failed to rename %s to %s: %s\n",
                             log->files[logNum], tmpFilename,
                             strerror(errno));
                     hasErrors = 1;
@@ -1905,7 +1905,7 @@ static int rotateSingleLog(struct logInfo *log, int logNum,
                         rotNames->finalName);
                 if (!debug && !hasErrors &&
                         rename(log->files[logNum], rotNames->finalName)) {
-                    message(MESS_ERROR, "error: failed to rename %s to %s: %s\n",
+                    message(MESS_ERROR, "failed to rename %s to %s: %s\n",
                             log->files[logNum], rotNames->finalName,
                             strerror(errno));
                     hasErrors = 1;

--- a/logrotate.c
+++ b/logrotate.c
@@ -1878,7 +1878,7 @@ static int rotateSingleLog(struct logInfo *log, int logNum,
 #ifdef WITH_ACL
             if ((prev_acl = acl_get_file(log->files[logNum], ACL_TYPE_ACCESS)) == NULL) {
                 if (is_acl_well_supported(errno)) {
-                    message(MESS_ERROR, "error getting file ACL %s: %s\n",
+                    message(MESS_ERROR, "getting file ACL %s: %s\n",
                             log->files[logNum], strerror(errno));
                     hasErrors = 1;
                 }

--- a/logrotate.c
+++ b/logrotate.c
@@ -1881,7 +1881,6 @@ static int rotateSingleLog(struct logInfo *log, int logNum,
                     message(MESS_ERROR, "error getting file ACL %s: %s\n",
                             log->files[logNum], strerror(errno));
                     hasErrors = 1;
-                833
 		  }
             }
 #endif /* WITH_ACL */

--- a/logrotate.c
+++ b/logrotate.c
@@ -1881,7 +1881,7 @@ static int rotateSingleLog(struct logInfo *log, int logNum,
                     message(MESS_ERROR, "error getting file ACL %s: %s\n",
                             log->files[logNum], strerror(errno));
                     hasErrors = 1;
-		  }
+                }
             }
 #endif /* WITH_ACL */
             if (log->flags & LOG_FLAG_TMPFILENAME) {

--- a/logrotate.c
+++ b/logrotate.c
@@ -1530,7 +1530,7 @@ static int prerotateSingleLog(struct logInfo *log, int logNum,
         while ((*dext != '\0') && (!hasErrors)) {
             /* Will there be a space for a char and '\0'? */
             if (j >= (sizeof(dext_pattern) - 1)) {
-                message(MESS_ERROR, "Date format %s is too long\n",
+                message(MESS_ERROR, "error: Date format %s is too long\n",
                         log->dateformat);
                 hasErrors = 1;
                 break;
@@ -1552,7 +1552,7 @@ static int prerotateSingleLog(struct logInfo *log, int logNum,
                                 sizeof(dext_pattern) - strlen(dext_pattern) - 1);
                         j += 10;
                         if (j >= (sizeof(dext_pattern) - 1)) {
-                            message(MESS_ERROR, "Date format %s is too long\n",
+                            message(MESS_ERROR, "error: Date format %s is too long\n",
                                     log->dateformat);
                             hasErrors = 1;
                             break;
@@ -1567,7 +1567,7 @@ static int prerotateSingleLog(struct logInfo *log, int logNum,
                                 sizeof(dext_pattern) - strlen(dext_pattern) - 1);
                         j += 50;
                         if (j >= (sizeof(dext_pattern) - 1)) {
-                            message(MESS_ERROR, "Date format %s is too long\n",
+                            message(MESS_ERROR, "error: Date format %s is too long\n",
                                     log->dateformat);
                             hasErrors = 1;
                             break;
@@ -1831,7 +1831,7 @@ static int prerotateSingleLog(struct logInfo *log, int logNum,
         }
         if (!stat(destFile, &fst_buf)) {
             message(MESS_ERROR,
-                    "destination %s already exists, skipping rotation\n",
+                    "error: destination %s already exists, skipping rotation\n",
                     rotNames->firstRotated);
             hasErrors = 1;
         }
@@ -1878,15 +1878,16 @@ static int rotateSingleLog(struct logInfo *log, int logNum,
 #ifdef WITH_ACL
             if ((prev_acl = acl_get_file(log->files[logNum], ACL_TYPE_ACCESS)) == NULL) {
                 if (is_acl_well_supported(errno)) {
-                    message(MESS_ERROR, "getting file ACL %s: %s\n",
+                    message(MESS_ERROR, "error getting file ACL %s: %s\n",
                             log->files[logNum], strerror(errno));
                     hasErrors = 1;
-                }
+                833
+		  }
             }
 #endif /* WITH_ACL */
             if (log->flags & LOG_FLAG_TMPFILENAME) {
                 if (asprintf(&tmpFilename, "%s%s", log->files[logNum], ".tmp") < 0) {
-                    message(MESS_FATAL, "could not allocate tmpFilename memory\n");
+                    message(MESS_FATAL, "error: could not allocate tmpFilename memory\n");
                     restoreSecCtx(&savedContext);
                     return 1;
                 }
@@ -1894,7 +1895,7 @@ static int rotateSingleLog(struct logInfo *log, int logNum,
                 message(MESS_DEBUG, "renaming %s to %s\n", log->files[logNum],
                         tmpFilename);
                 if (!debug && !hasErrors && rename(log->files[logNum], tmpFilename)) {
-                    message(MESS_ERROR, "failed to rename %s to %s: %s\n",
+                    message(MESS_ERROR, "error: failed to rename %s to %s: %s\n",
                             log->files[logNum], tmpFilename,
                             strerror(errno));
                     hasErrors = 1;
@@ -1905,7 +1906,7 @@ static int rotateSingleLog(struct logInfo *log, int logNum,
                         rotNames->finalName);
                 if (!debug && !hasErrors &&
                         rename(log->files[logNum], rotNames->finalName)) {
-                    message(MESS_ERROR, "failed to rename %s to %s: %s\n",
+                    message(MESS_ERROR, "error: failed to rename %s to %s: %s\n",
                             log->files[logNum], rotNames->finalName,
                             strerror(errno));
                     hasErrors = 1;

--- a/logrotate.c
+++ b/logrotate.c
@@ -2807,6 +2807,9 @@ int main(int argc, const char **argv)
     if (!debug)
         rc |= writeState(stateFile);
 
+    if (debug && rc)
+        message(MESS_ERROR, "logrotate has had %d errors",  rc);
+
     return (rc != 0);
 }
 


### PR DESCRIPTION
# What
Improving error messaging.
* This PR adds the "error" prefix to messages that make the exit code non-zero, making the output simple to `grep` "error".  
* Output the total number of errors detected before exiting

# Why?
When certain pieces of code change the exit-code to 1 and don't say the word error in their output, it makes it challenging to determine why logrotate is failing its checks without diving into the code.

## Example
From the output of `logrotate -d`, it looks like there are no problems, it just exits 1.  So you comb through the output looking for a message that indicates the reason, but nothing looks like a failure. You see a message like
>destination /var/log/something/something already exists, skipping rotation

This is an error and is raising the exit code, but it is unclear that this is the behavior that is causing the failure



Related to https://github.com/logrotate/logrotate/issues/238