### PR TITLE
config: add variable initialization [-Wconditional-uninitialized]

### DIFF
--- a/config.c
+++ b/config.c
@@ -284,7 +284,7 @@ static int readModeUidGid(const char *configFile, int lineNum, char *key,
                           gid_t *pGid)
 {
     char u[200], g[200];
-    unsigned int m;
+    unsigned int m = 0;
     char tmp;
     int rc;
 


### PR DESCRIPTION
Noticed when compiling with clang.

config.c:314:17: warning: variable 'm' may be uninitialized when used here
config.c:287:19: note: initialize the variable 'm' to silence this warning

Signed-off-by: Sami Kerola <kerolasa@iki.fi>