### PR TITLE
Fix so that args are actually passed to scripts.

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -451,7 +451,7 @@ static int runScript(struct logInfo *log, char *logfn, char *logrotfn, char *scr
                 exit(1);
             }
         }
-        execl("/bin/sh", "sh", "-c", script, "logrotate_script", logfn, logrotfn, (char *) NULL);
+        execl("/bin/sh", "sh", script, logfn, logrotfn, (char *) NULL);
         exit(1);
     }
 


### PR DESCRIPTION
Two bugs fixed:
 * the "-c" argument to "sh" causes subsequent args to "sh"
   to *not* be passed to the script given in the "-c" value
 * the "logrotate_script" arg ends up as arg1 of the script,
   which isn't documented anywhere, and was probably thought
   to end up as arg0 of the script, so delete

This fixes issue #244 (and issue #7).