### PR TITLE
examples/btmp: use create mode 0660

### DIFF
--- a/examples/btmp
+++ b/examples/btmp
@@ -2,6 +2,6 @@
 /var/log/btmp {
     missingok
     monthly
-    create 0600 root utmp
+    create 0660 root utmp
     rotate 1
 }


### PR DESCRIPTION
... to make the created file accessible by the utmp group.

Bug: https://bugzilla.redhat.com/1745330
Suggested-by: Steve Grubb