### PR TITLE
man page: mention cfg files must not be group-writable nor world-writable

### DIFF
--- a/logrotate.8.in
+++ b/logrotate.8.in
@@ -576,7 +576,8 @@ before processing of the including file continues. The only files
 which are ignored are files which are not regular files (such as
 directories and named pipes) and files whose names end with one of
 the taboo extensions or patterns, as specified by the \fBtabooext\fR
-or \fBtaboopat\fR directives, respectively.
+or \fBtaboopat\fR directives, respectively.  For security reasons
+configuration files must not be group-writable nor world-writable.
 
 .TP
 \fBsharedscripts\fR


### PR DESCRIPTION
Originated from https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=691407