### PR TITLE
Date/Time format and debug messages improvements

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -1266,8 +1266,8 @@ static int findNeedRotating(struct logInfo *log, int logNum, int force)
                             && now.tm_wday == log->weekday);
                 if (!state->doRotate) {
                     message(MESS_DEBUG, "  log does not need rotating "
-                            "(log has been rotated at %d-%d-%d %d:%d, "
-                            "that is not week ago yet)\n", 1900 + state->lastRotated.tm_year,
+                            "(log has been rotated at %d-%02d-%02d %02d:%02d, "
+                            "which is less than a week ago)\n", 1900 + state->lastRotated.tm_year,
                             1 + state->lastRotated.tm_mon, state->lastRotated.tm_mday,
                             state->lastRotated.tm_hour, state->lastRotated.tm_min);
                 }
@@ -1279,8 +1279,8 @@ static int findNeedRotating(struct logInfo *log, int logNum, int force)
                         (now.tm_year != state->lastRotated.tm_year));
                 if (!state->doRotate) {
                     message(MESS_DEBUG, "  log does not need rotating "
-                            "(log has been rotated at %d-%d-%d %d:%d, "
-                            "that is not hour ago yet)\n", 1900 + state->lastRotated.tm_year,
+                            "(log has been rotated at %d-%02d-%02d %02d:%02d, "
+                            "which is less than an hour ago)\n", 1900 + state->lastRotated.tm_year,
                             1 + state->lastRotated.tm_mon, state->lastRotated.tm_mday,
                             state->lastRotated.tm_hour, state->lastRotated.tm_min);
                 }
@@ -1292,8 +1292,8 @@ static int findNeedRotating(struct logInfo *log, int logNum, int force)
                         (now.tm_year != state->lastRotated.tm_year));
                 if (!state->doRotate) {
                     message(MESS_DEBUG, "  log does not need rotating "
-                            "(log has been rotated at %d-%d-%d %d:%d, "
-                            "that is not day ago yet)\n", 1900 + state->lastRotated.tm_year,
+                            "(log has been rotated at %d-%02d-%02d %02d:%02d, "
+                            "which is less than a day ago)\n", 1900 + state->lastRotated.tm_year,
                             1 + state->lastRotated.tm_mon, state->lastRotated.tm_mday,
                             state->lastRotated.tm_hour, state->lastRotated.tm_min);
                 }
@@ -1305,8 +1305,8 @@ static int findNeedRotating(struct logInfo *log, int logNum, int force)
                         (now.tm_year != state->lastRotated.tm_year));
                 if (!state->doRotate) {
                     message(MESS_DEBUG, "  log does not need rotating "
-                            "(log has been rotated at %d-%d-%d %d:%d, "
-                            "that is not month ago yet)\n", 1900 + state->lastRotated.tm_year,
+                            "(log has been rotated at %d-%02d-%02d %02d:%02d, "
+                            "which is less than a month ago)\n", 1900 + state->lastRotated.tm_year,
                             1 + state->lastRotated.tm_mon, state->lastRotated.tm_mday,
                             state->lastRotated.tm_hour, state->lastRotated.tm_min);
                 }
@@ -1316,8 +1316,8 @@ static int findNeedRotating(struct logInfo *log, int logNum, int force)
                 state->doRotate = (now.tm_year != state->lastRotated.tm_year);
                 if (!state->doRotate) {
                     message(MESS_DEBUG, "  log does not need rotating "
-                            "(log has been rotated at %d-%d-%d %d:%d, "
-                            "that is not year ago yet)\n", 1900 + state->lastRotated.tm_year,
+                            "(log has been rotated at %d-%02d-%02d %02d:%02d, "
+                            "which is less than a year ago)\n", 1900 + state->lastRotated.tm_year,
                             1 + state->lastRotated.tm_mon, state->lastRotated.tm_mday,
                             state->lastRotated.tm_hour, state->lastRotated.tm_min);
                 }
@@ -1343,7 +1343,7 @@ static int findNeedRotating(struct logInfo *log, int logNum, int force)
     }
     else if (!state->doRotate) {
         message(MESS_DEBUG, "  log does not need rotating "
-                "(log has been already rotated)\n");
+                "(log has already been rotated)\n");
     }
 
     /* The notifempty flag overrides the normal criteria */


### PR DESCRIPTION
Hi! While doing a little bit of debugging with `logrotate` I noticed that timestamps did not have proper format, at least values did not always take two places, and pad with zero where a value is less than 10. I also observed messages being somewhat less than well-formed, so decided to do a little bit of cleanup. Hopefully this will be acceptable. It certainly looks better now.

Some examples of resulting changes:
```
<   log does not need rotating (log has been rotated at 2019-9-12 4:0, that is not month ago yet)
---
>   log does not need rotating (log has been rotated at 2019-09-12 04:00, which is less than a month ago)

<   log does not need rotating (log has been rotated at 2019-9-22 4:2, that is not week ago yet)
---
>   log does not need rotating (log has been rotated at 2019-09-22 04:02, which is less than a week ago)
```
Let me know if this is acceptable, or if you would like something else done, etc. Feel free to close if for whatever reason this is not acceptable.

Thanks, Sam.