### PR TITLE
some fixes

### DIFF
--- a/config.c
+++ b/config.c
@@ -912,10 +912,6 @@ static int readConfigFile(const char *configFile, struct logInfo *defConfig)
         .l_type = F_RDLCK
     };
 
-    /* FIXME: createOwner and createGroup probably shouldn't be fixed
-       length arrays -- of course, if we aren't run setuid it doesn't
-       matter much */
-
     fd = open(configFile, O_RDONLY);
     if (fd < 0) {
         message(MESS_ERROR, "failed to open config file %s: %s\n",

--- a/config.c
+++ b/config.c
@@ -499,6 +499,8 @@ static void copyLogInfo(struct logInfo *to, struct logInfo *from)
     }
     if (from->dateformat)
         to->dateformat = strdup(from->dateformat);
+
+    to->list = from->list;
 }
 
 static void freeLogInfo(struct logInfo *log)

--- a/config.c
+++ b/config.c
@@ -541,6 +541,7 @@ static void removeLogInfo(struct logInfo *log)
 
     freeLogInfo(log);
     TAILQ_REMOVE(&logs, log, list);
+    free(log);
     numLogs--;
 }
 

--- a/logrotate.c
+++ b/logrotate.c
@@ -1491,18 +1491,20 @@ static int prerotateSingleLog(struct logInfo *log, int logNum,
         fileext = log->addextension;
     }
 
-    if (log->extension &&
-            strncmp(&
-                (rotNames->
-                 baseName[strlen(rotNames->baseName) -
-                 strlen(log->extension)]), log->extension,
-                strlen(log->extension)) == 0) {
-        char *tempstr;
+    if (log->extension) {
+        const size_t baseLen = strlen(rotNames->baseName);
+        const size_t extLen = strlen(log->extension);
 
-        fileext = log->extension;
-        tempstr = strndup(rotNames->baseName, strlen(rotNames->baseName) - strlen(log->extension));
-        free(rotNames->baseName);
-        rotNames->baseName = tempstr;
+        if (baseLen >= extLen &&
+                strncmp(&(rotNames->baseName[baseLen - extLen]),
+                    log->extension, extLen) == 0) {
+            char *tempstr;
+
+            fileext = log->extension;
+            tempstr = strndup(rotNames->baseName, baseLen - extLen);
+            free(rotNames->baseName);
+            rotNames->baseName = tempstr;
+        }
     }
 
     /* Adjust "now" if we want yesterday's date */

--- a/logrotate.c
+++ b/logrotate.c
@@ -1501,6 +1501,7 @@ static int prerotateSingleLog(struct logInfo *log, int logNum,
 
         fileext = log->extension;
         tempstr = strndup(rotNames->baseName, strlen(rotNames->baseName) - strlen(log->extension));
+        free(rotNames->baseName);
         rotNames->baseName = tempstr;
     }
 

--- a/logrotate.c
+++ b/logrotate.c
@@ -2674,7 +2674,7 @@ int main(int argc, const char **argv)
 {
     int force = 0;
     const char *stateFile = STATEFILE;
-    char *logFile = NULL;
+    const char *logFile = NULL;
     FILE *logFd = NULL;
     int rc = 0;
     int arg;

--- a/logrotate.c
+++ b/logrotate.c
@@ -265,6 +265,9 @@ static int allocateHash(unsigned int hs)
 }
 
 #define HASH_CONST 13
+#if defined(__clang__) && defined(__clang_major__) && (__clang_major__ >= 4)
+__attribute__((no_sanitize("unsigned-integer-overflow")))
+#endif
 static int hashIndex(const char *fn)
 {
     unsigned hash = 0;

--- a/logrotate.c
+++ b/logrotate.c
@@ -2764,7 +2764,7 @@ int main(int argc, const char **argv)
         return 2;
     }
 
-    files = poptGetArgs((poptContext) optCon);
+    files = poptGetArgs(optCon);
     if (!files) {
         fprintf(stderr, "logrotate " VERSION
                 " - Copyright (C) 1995-2001 Red Hat, Inc.\n");


### PR DESCRIPTION
- main: remove unneeded cast
- main: contify logfile argument
- hashIndex: whitelist intentional unsigned integer overflow
- prerotateSingleLog: fix memory leak
- prerotateSingleLog: fix heap-buffer-overflow
- removeLogInfo: fix memory leak
- copyLogInfo: copy queue information to avoid SEGV

see single commits for more info