### PR TITLE
draft: re-inforce logrotate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,9 +110,9 @@ install:
 script:
   - $COMPILER --version
   - ./autogen.sh
-  - ./configure --enable-werror CC=$COMPILER
+  - ./configure --enable-werror CC=$COMPILER --disable-silent-rules
   - make
-  - make -j9 check
+  - make -j9 check || ( cat test/test-suite.log; exit 1; )
   - make -j9 distcheck
   # nodeps because rpm build deps can not be installed on debian system
   - make rpm RPM_FLAGS="--nodeps"

--- a/Makefile.am
+++ b/Makefile.am
@@ -10,7 +10,7 @@
 #
 AM_CPPFLAGS = -include config.h
 sbin_PROGRAMS = logrotate
-logrotate_SOURCES = config.c log.c logrotate.c \
+logrotate_SOURCES = config.c log.c logrotate.c common.c \
 		    log.h logrotate.h queue.h
 
 dist_man_MANS = logrotate.8 logrotate.conf.5

--- a/common.c
+++ b/common.c
@@ -1,0 +1,253 @@
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+#include <libgen.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include "log.h"
+#include "logrotate.h"
+
+
+#define MAX_SYMLINKS  5
+
+/**
+ * Returns CHK_SECURE     if directory is secure,
+ *         CHK_ERROR      on error,
+ *         CHK_NOTDIR     if a part of the path is not a directory,
+ *         CHK_FAIL_OWNER if a (parent) directory is owned by someone besides user and root,
+ *         CHK_FAIL_GROUP if a (parent) directory is writable by group except the root group,
+ *         CHK_FAIL_OTHER if a (parent) directory is writable by others
+ *
+ * adopted from https://wiki.sei.cmu.edu/confluence/display/c/FIO15-C.+Ensure+that+file+operations+are+performed+in+a+secure+directory
+ */
+int check_dir_secure(const char *fullpath) {
+    static unsigned num_symlinks = 0;
+    char **dirs;
+    int num_of_dirs = 1;
+    int secure = CHK_SECURE;
+    int i;
+    struct stat buf;
+    uid_t my_uid = geteuid();
+
+    if (!fullpath || fullpath[0] != '/') {
+        message(MESS_ERROR, "invalid directory %s to check\n", fullpath ? fullpath : "()");
+        return CHK_ERROR;
+    }
+
+    if (num_symlinks > MAX_SYMLINKS) {
+        message(MESS_ERROR, "directory %s has too many parent symlinks\n", fullpath);
+        return CHK_ERROR;
+    }
+
+    {
+        char *path_parent;
+        char *path_copy = strdup(fullpath);
+
+        if (path_copy == NULL) {
+            message(MESS_ERROR, "can not allocate memory\n");
+            return CHK_ERROR;
+        }
+
+        /* Figure out how far it is to the root */
+        for (path_parent = path_copy; ((strcmp(path_parent, "/") != 0) &&
+                (strcmp(path_parent, "//") != 0) &&
+                (strcmp(path_parent, ".") != 0));
+            path_parent = dirname(path_parent)) {
+            num_of_dirs++;
+        } /* Now num_of_dirs indicates # of dirs we must check */
+        free(path_copy);
+    }
+
+    dirs = malloc(num_of_dirs * sizeof(char *));
+    if (dirs == NULL) {
+        message(MESS_ERROR, "can not allocate memory\n");
+        return CHK_ERROR;
+    }
+
+    dirs[num_of_dirs - 1] = strdup(fullpath);
+    if (dirs[num_of_dirs - 1] == NULL) {
+        message(MESS_ERROR, "can not allocate memory\n");
+        free(dirs);
+        return CHK_ERROR;
+    }
+
+    {
+        char *path_parent;
+        char *path_copy = strdup(fullpath);
+
+        if (path_copy == NULL) {
+            message(MESS_ERROR, "can not allocate memory\n");
+            free(dirs);
+            return CHK_ERROR;
+        }
+
+        /* Now fill the dirs array */
+        path_parent = path_copy;
+        for (i = num_of_dirs - 2; i >= 0; i--) {
+            path_parent = dirname(path_parent);
+            dirs[i] = strdup(path_parent);
+            if (dirs[i] == NULL) {
+                int j;
+
+                message(MESS_ERROR, "can not allocate memory\n");
+                for (j = num_of_dirs - 1; j > i; j--) {
+                    free(dirs[j]);
+                }
+                free(path_copy);
+                free(dirs);
+                return CHK_ERROR;
+            }
+        }
+        free(path_copy);
+    }
+
+    /*
+     * Traverse from the root to the fullpath,
+     * checking permissions along the way.
+     */
+    for (i = 0; i < num_of_dirs; i++) {
+        if (lstat(dirs[i], &buf) != 0) {
+            message(MESS_ERROR, "can not stat directory %s: %s\n", dirs[i], strerror(errno));
+            secure = CHK_ERROR;
+            break;
+        }
+
+        if (S_ISLNK(buf.st_mode)) { /* Symlink, test linked-to file */
+            size_t linksize = buf.st_size + 1;
+            ssize_t r;
+            int rv;
+            char *link_path = malloc(linksize);
+
+            if (link_path == NULL) {
+                message(MESS_ERROR, "can not allocate memory\n");
+                secure = CHK_ERROR;
+                break;
+            }
+
+            r = readlink(dirs[i], link_path, linksize);
+            if (r < 0) {
+                message(MESS_ERROR, "can not readlink %s: %s\n", dirs[i], strerror(errno));
+                secure = CHK_ERROR;
+                free(link_path);
+                break;
+            } else if ((size_t)r >= linksize) {
+                message(MESS_ERROR, "link destination of %s too long (%lu/%lu): %s\n", dirs[i], (size_t)r, linksize, strerror(errno));
+                secure = CHK_ERROR;
+                free(link_path);
+                break;
+            }
+            link_path[r] = '\0';
+
+            num_symlinks++;
+            rv = check_dir_secure(link_path);
+            num_symlinks--;
+
+            free(link_path);
+
+            if (rv != 0) {
+                secure = rv;
+                break;
+            }
+
+            continue;
+        }
+
+        if (!S_ISDIR(buf.st_mode)) { /* Not a directory */
+            secure = CHK_NOTDIR;
+            break;
+        }
+
+        if ((buf.st_uid != my_uid) && (buf.st_uid != 0)) {
+            /* Directory is owned by someone besides user or root */
+            secure = CHK_FAIL_OWNER;
+            break;
+        }
+
+        if (buf.st_gid != 0 && (buf.st_mode & S_IWGRP)) { /* dir is writable by group */
+            secure = CHK_FAIL_GROUP;
+            break;
+        }
+
+        if (buf.st_mode & S_IWOTH) { /* dir is writable by everyone */
+            secure = CHK_FAIL_OTHER;
+            break;
+        }
+    }
+
+    for (i = 0; i < num_of_dirs; i++) {
+        free(dirs[i]);
+    }
+    free(dirs);
+
+    return secure;
+}
+
+#define BUF_LEN 1024
+
+/**
+ * Returns CHK_SECURE     if filepath is inside a secure directory,
+ *         CHK_ERROR      on error,
+ *         CHK_NOTDIR     if a part of the path is not a directory,
+ *         CHK_FAIL_OWNER if a parent directory is owned by someone besides user and root,
+ *         CHK_FAIL_GROUP if a parent directory is writable by group except the root group,
+ *         CHK_FAIL_OTHER if a parent directory is writable by others
+ */
+int check_file_in_secure_dir(const char *filepath) {
+    char buf[BUF_LEN];
+
+    if (filepath == NULL) {
+        message(MESS_ERROR, "invalid file to check\n");
+        return CHK_ERROR;
+    }
+
+    if (filepath[0] == '/') {
+        int rv;
+        char *path_parent;
+        char *path_copy = strdup(filepath);
+
+        if (path_copy == NULL) {
+            message(MESS_ERROR, "can not allocate memory\n");
+            return CHK_ERROR;
+        }
+
+        path_parent = dirname(path_copy);
+
+        rv = check_dir_secure(path_parent);
+
+        free(path_copy);
+
+        return rv;
+    }
+
+    if (getcwd(buf, BUF_LEN) == NULL) {
+        message(MESS_ERROR, "can not get current directory name: %s\n", strerror(errno));
+        return CHK_ERROR;
+    }
+
+    return check_dir_secure(buf);
+}
+
+/**
+ * Returns CHK_SECURE     if path is a secure directory or a file inside one,
+ *         CHK_ERROR      on error,
+ *         CHK_NOTDIR     if a part of the path is not a directory,
+ *         CHK_FAIL_OWNER if a (parent) directory is owned by someone besides user and root,
+ *         CHK_FAIL_GROUP if a (parent) directory is writable by group except the root group,
+ *         CHK_FAIL_OTHER if a (parent) directory is writable by others
+ */
+int check_path_secure(const char *path) {
+    struct stat sb;
+
+    if (stat(path, &sb) == -1) {
+        message(MESS_ERROR, "can not stat %s: %s\n", path, strerror(errno));
+        return CHK_ERROR;
+    }
+
+    if (S_ISDIR(sb.st_mode)) {
+        return check_dir_secure(path);
+    }
+
+    return check_file_in_secure_dir(path);
+}

--- a/config.c
+++ b/config.c
@@ -770,6 +770,12 @@ int readAllConfigPaths(const char **paths)
     };
 
     tabooPatterns = malloc(sizeof(*tabooPatterns) * defTabooCount);
+    if (tabooPatterns == NULL) {
+        message(MESS_ERROR, "can not allocate memory\n");
+        return 1;
+    }
+
+
     for (i = 0; i < defTabooCount; i++) {
         int bytes;
         char *pattern = NULL;

--- a/config.c
+++ b/config.c
@@ -391,6 +391,11 @@ static int mkpath(const char *path, mode_t mode, uid_t uid, gid_t gid) {
     int rv;
     char *copypath = strdup(path);
 
+    if (!copypath) {
+        message(MESS_ERROR, "can not allocate memory\n");
+        return 1;
+    }
+
     rv = 0;
     pp = copypath;
     while (rv == 0 && (sp = strchr(pp, '/')) != NULL) {

--- a/config.c
+++ b/config.c
@@ -527,8 +527,11 @@ static struct logInfo *newLogInfo(const struct logInfo *template)
 {
     struct logInfo *new;
 
-    if ((new = malloc(sizeof(*new))) == NULL)
+    new = malloc(sizeof(*new));
+    if (new == NULL) {
+        message(MESS_ERROR, "can not allocate memory\n");
         return NULL;
+    }
 
     copyLogInfo(new, template);
     TAILQ_INSERT_TAIL(&logs, new, list);

--- a/config.c
+++ b/config.c
@@ -607,6 +607,20 @@ static int readConfigPath(const char *path, struct logInfo *defConfig)
     int fd;
     struct logInfo defConfigBackup;
 
+    if (getuid() == ROOT_UID) {
+        int secure = check_path_secure(path);
+        if (secure == CHK_ERROR) {
+            /* error message already printed */
+            return 1;
+        }
+        if (secure != CHK_SECURE) {
+            message(MESS_ERROR, "configuration path %s is not secure; "
+                    "itself or some of it parents might be world writable or "
+                    "writable by a group which is not \"root\"\n", path);
+            return 1;
+        }
+    }
+
     fd = open(path, O_RDONLY);
     if (fd == -1) {
         message(MESS_ERROR, "can not open %s: %s\n", path, strerror(errno));

--- a/config.c
+++ b/config.c
@@ -789,7 +789,7 @@ static char* parseGlobString(const char *configFile, int lineNum,
             default:
                 if ('\n' == **ppos)
                     state = PGS_INIT;
-        };
+        }
 
         if (PGS_COMMENT == state)
             /* skip comment */
@@ -862,7 +862,7 @@ static int globerr(const char *pathname, int theerr)
     do { \
         free(newlog->what); \
         newlog->what = NULL; \
-    } while (0);
+    } while (0)
 #define RAISE_ERROR() \
     if (newlog != defConfig) { \
         state = STATE_ERROR; \

--- a/config.c
+++ b/config.c
@@ -1857,10 +1857,7 @@ duperror:
                         while (*endtag != '\n')
                             endtag--;
                         endtag++;
-                        *scriptDest = malloc(endtag - scriptStart + 1);
-                        strncpy(*scriptDest, scriptStart,
-                                endtag - scriptStart);
-                        (*scriptDest)[endtag - scriptStart] = '\0';
+                        *scriptDest = strndup(scriptStart, endtag - scriptStart);
 
                         scriptDest = NULL;
                         scriptStart = NULL;

--- a/config.c
+++ b/config.c
@@ -2007,7 +2007,7 @@ duperror:
                 }
                 break;
             default:
-                message(MESS_DEBUG,
+                message(MESS_FATAL,
                         "%s: %d: readConfigFile() unknown state\n",
                         configFile, lineNum);
         }

--- a/config.c
+++ b/config.c
@@ -628,9 +628,8 @@ static int readConfigPath(const char *path, struct logInfo *defConfig)
                     }
                 }
                 /* Alloc memory for file name */
-                if ((namelist[files_count] =
-                            (char *) malloc(strlen(dp->d_name) + 1))) {
-                    strcpy(namelist[files_count], dp->d_name);
+                namelist[files_count] = strdup(dp->d_name);
+                if (namelist[files_count] != NULL) {
                     files_count++;
                 } else {
                     free_2d_array(namelist, files_count);

--- a/config.c
+++ b/config.c
@@ -450,11 +450,24 @@ static void free_2d_array(char **array, int lines_count)
     free(array);
 }
 
-static void copyLogInfo(struct logInfo *to, const struct logInfo *from)
+#define MEMBERCOPY(dest, src) \
+    do { \
+        if (src && rv == 0) { \
+            (dest) = strdup(src); \
+            if ((dest) == NULL) { \
+                message(MESS_ERROR, "can not allocate memory\n"); \
+                rv = 1; \
+            } \
+        } else { \
+            (dest) = NULL; \
+        } \
+    } while (0)
+static int copyLogInfo(struct logInfo *to, const struct logInfo *from)
 {
+    int rv = 0;
+
     memset(to, 0, sizeof(*to));
-    if (from->oldDir)
-        to->oldDir = strdup(from->oldDir);
+    MEMBERCOPY(to->oldDir, from->oldDir);
     to->criterium = from->criterium;
     to->weekday = from->weekday;
     to->threshold = from->threshold;
@@ -464,26 +477,16 @@ static void copyLogInfo(struct logInfo *to, const struct logInfo *from)
     to->rotateMinAge = from->rotateMinAge;
     to->rotateAge = from->rotateAge;
     to->logStart = from->logStart;
-    if (from->pre)
-        to->pre = strdup(from->pre);
-    if (from->post)
-        to->post = strdup(from->post);
-    if (from->first)
-        to->first = strdup(from->first);
-    if (from->last)
-        to->last = strdup(from->last);
-    if (from->preremove)
-        to->preremove = strdup(from->preremove);
-    if (from->logAddress)
-        to->logAddress = strdup(from->logAddress);
-    if (from->extension)
-        to->extension = strdup(from->extension);
-    if (from->compress_prog)
-        to->compress_prog = strdup(from->compress_prog);
-    if (from->uncompress_prog)
-        to->uncompress_prog = strdup(from->uncompress_prog);
-    if (from->compress_ext)
-        to->compress_ext = strdup(from->compress_ext);
+    MEMBERCOPY(to->pre, from->pre);
+    MEMBERCOPY(to->post, from->post);
+    MEMBERCOPY(to->first, from->first);
+    MEMBERCOPY(to->last, from->last);
+    MEMBERCOPY(to->preremove, from->preremove);
+    MEMBERCOPY(to->logAddress , from->logAddress);
+    MEMBERCOPY(to->extension, from->extension);
+    MEMBERCOPY(to->compress_prog, from->compress_prog);
+    MEMBERCOPY(to->uncompress_prog, from->uncompress_prog);
+    MEMBERCOPY(to->compress_ext, from->compress_ext);
     to->flags = from->flags;
     to->shred_cycles = from->shred_cycles;
     to->createMode = from->createMode;
@@ -494,15 +497,23 @@ static void copyLogInfo(struct logInfo *to, const struct logInfo *from)
     to->olddirMode = from->olddirMode;
     to->olddirUid = from->olddirUid;
     to->olddirGid = from->olddirGid;
+
     if (from->compress_options_count) {
         poptDupArgv(from->compress_options_count, from->compress_options_list,
                     &to->compress_options_count,  &to->compress_options_list);
+        if (to->compress_options_list == NULL) {
+            message(MESS_ERROR, "can not allocate memory\n");
+            rv = 1;
+        }
     }
-    if (from->dateformat)
-        to->dateformat = strdup(from->dateformat);
+
+    MEMBERCOPY(to->dateformat, from->dateformat);
 
     to->list = from->list;
+
+    return rv;
 }
+#undef MEMBERCOPY
 
 static void freeLogInfo(struct logInfo *log)
 {
@@ -533,7 +544,12 @@ static struct logInfo *newLogInfo(const struct logInfo *template)
         return NULL;
     }
 
-    copyLogInfo(new, template);
+    if (copyLogInfo(new, template)) {
+        freeLogInfo(new);
+        free(new);
+        return NULL;
+    }
+
     TAILQ_INSERT_TAIL(&logs, new, list);
     numLogs++;
 
@@ -692,12 +708,17 @@ static int readConfigPath(const char *path, struct logInfo *defConfig)
                 continue;
             }
 
-            copyLogInfo(&defConfigBackup, defConfig);
+            if (copyLogInfo(&defConfigBackup, defConfig)) {
+                freeLogInfo(&defConfigBackup);
+                close(fd_i);
+                result = 1;
+                continue;
+            }
 
             if (readConfigFile(fd_i, namelist[i], defConfig)) {
                 message(MESS_ERROR, "found error in file %s, skipping\n", namelist[i]);
                 freeLogInfo(defConfig);
-                copyLogInfo(defConfig, &defConfigBackup);
+                copyLogInfo(defConfig, &defConfigBackup); /* do not check, we are already in a error path */
                 freeLogInfo(&defConfigBackup);
                 close(fd_i);
                 result = 1;
@@ -713,10 +734,11 @@ static int readConfigPath(const char *path, struct logInfo *defConfig)
         close(here);
         free_2d_array(namelist, files_count);
     } else { /* !S_ISDIR(sb.st_mode) */
-        copyLogInfo(&defConfigBackup, defConfig);
-        if (readConfigFile(fd, path, defConfig)) {
+        if (copyLogInfo(&defConfigBackup, defConfig)) {
+            result = 1;
+        } else if (readConfigFile(fd, path, defConfig)) {
             freeLogInfo(defConfig);
-            copyLogInfo(defConfig, &defConfigBackup);
+            copyLogInfo(defConfig, &defConfigBackup); /* do not check, we are already in a error path */
             result = 1;
         }
         freeLogInfo(&defConfigBackup);

--- a/config.c
+++ b/config.c
@@ -433,7 +433,7 @@ static int checkFile(const char *fname)
 /* Used by qsort to sort filelist */
 static int compar(const void *p, const void *q)
 {
-    return strcoll(*((char **) p), *((char **) q));
+    return strcoll(*((char * const*) p), *((char * const*) q));
 }
 
 /* Free memory blocks pointed to by pointers in a 2d array and the array itself */
@@ -1514,7 +1514,7 @@ static int readConfigFile(const char *configFile, struct logInfo *defConfig)
                         for(i = 0; i < compress_cmd_list_size; i++) {
                             if (!strcmp(compress_cmd_list[i].cmd, compresscmd_base)) {
                                 freeLogItem (compress_ext);
-                                newlog->compress_ext = strdup((char *)compress_cmd_list[i].ext);
+                                newlog->compress_ext = strdup(compress_cmd_list[i].ext);
                                 message(MESS_DEBUG, "compress_ext was changed to %s\n", newlog->compress_ext);
                                 break;
                             }

--- a/config.c
+++ b/config.c
@@ -1845,7 +1845,7 @@ duperror:
                             }
 
                             if (stat(dirName, &sb)) {
-                                if (errno == ENOENT && newlog->flags & LOG_FLAG_OLDDIRCREATE) {
+                                if (errno == ENOENT && (newlog->flags & LOG_FLAG_OLDDIRCREATE)) {
                                     int ret;
                                     if (newlog->flags & LOG_FLAG_SU) {
                                         if (switch_user(newlog->suUid, newlog->suGid) != 0) {
@@ -1901,7 +1901,7 @@ duperror:
             case STATE_SKIP_LINE:
             case STATE_SKIP_LINE | STATE_SKIP_CONFIG:
                 if (*start == '\n')
-                    state = state & STATE_SKIP_CONFIG ? STATE_SKIP_CONFIG : STATE_DEFAULT;
+                    state = (state & STATE_SKIP_CONFIG) ? STATE_SKIP_CONFIG : STATE_DEFAULT;
                 break;
             case STATE_SKIP_LINE | STATE_LOAD_SCRIPT:
                 if (*start == '\n')
@@ -1918,10 +1918,10 @@ duperror:
                 if (*start != '\n') {
                     message(MESS_ERROR, "%s:%d, unexpected text after }\n",
                             configFile, lineNum);
-                    state = STATE_SKIP_LINE | (state & STATE_SKIP_CONFIG ? STATE_SKIP_CONFIG : 0);
+                    state = STATE_SKIP_LINE | ((state & STATE_SKIP_CONFIG) ? STATE_SKIP_CONFIG : 0);
                 }
                 else
-                    state = state & STATE_SKIP_CONFIG ? STATE_SKIP_CONFIG : STATE_DEFAULT;
+                    state = (state & STATE_SKIP_CONFIG) ? STATE_SKIP_CONFIG : STATE_DEFAULT;
                 break;
             case STATE_ERROR:
                 assert(newlog != defConfig);
@@ -1957,12 +1957,12 @@ duperror:
                         scriptDest = NULL;
                         scriptStart = NULL;
                     }
-                    state = state & STATE_SKIP_CONFIG ? STATE_SKIP_CONFIG : STATE_DEFAULT;
+                    state = (state & STATE_SKIP_CONFIG) ? STATE_SKIP_CONFIG : STATE_DEFAULT;
                 }
                 else {
                     state = (*start == '\n' ? 0 : STATE_SKIP_LINE) |
                         STATE_LOAD_SCRIPT |
-                        (state & STATE_SKIP_CONFIG ? STATE_SKIP_CONFIG : 0);
+                        ((state & STATE_SKIP_CONFIG) ? STATE_SKIP_CONFIG : 0);
                 }
                 break;
             case STATE_SKIP_CONFIG:

--- a/config.c
+++ b/config.c
@@ -445,7 +445,7 @@ static void free_2d_array(char **array, int lines_count)
     free(array);
 }
 
-static void copyLogInfo(struct logInfo *to, struct logInfo *from)
+static void copyLogInfo(struct logInfo *to, const struct logInfo *from)
 {
     memset(to, 0, sizeof(*to));
     if (from->oldDir)
@@ -518,7 +518,7 @@ static void freeLogInfo(struct logInfo *log)
     free(log->dateformat);
 }
 
-static struct logInfo *newLogInfo(struct logInfo *template)
+static struct logInfo *newLogInfo(const struct logInfo *template)
 {
     struct logInfo *new;
 

--- a/config.c
+++ b/config.c
@@ -844,7 +844,7 @@ static char* parseGlobString(const char *configFile, int lineNum,
             globStringAlloc += GLOB_STR_REALLOC_STEP;
             ptr = realloc(globString, globStringAlloc);
             if (!ptr) {
-                /* out of memory */
+                message(MESS_ERROR, "can not realloc\n");
                 free(globString);
                 return NULL;
             }

--- a/config.c
+++ b/config.c
@@ -1076,7 +1076,6 @@ static int readConfigFile(int fd, const char *configFile, struct logInfo *defCon
 
     message(MESS_DEBUG, "reading config file %s\n", configFile);
 
-    start = buf;
     for (start = buf; start - buf < length; start++) {
         switch (state) {
             case STATE_DEFAULT:

--- a/log.c
+++ b/log.c
@@ -93,7 +93,7 @@ void message(int level, const char *format, ...)
             default:
                 priority |= LOG_INFO;
                 break;
-        };
+        }
 
         va_start(args, format);
         vsyslog(priority, format, args);

--- a/logrotate.c
+++ b/logrotate.c
@@ -2649,7 +2649,8 @@ static int readState(const char *stateFilename)
             return 1;
         }
 
-        year -= 1900, month -= 1;
+        year -= 1900;
+        month -= 1;
 
         filename = strdup(argv[0]);
         unescape(filename);

--- a/logrotate.c
+++ b/logrotate.c
@@ -2553,7 +2553,6 @@ static int readState(const char *stateFilename)
     int argc;
     int year, month, day, hour, minute, second;
     int fd;
-    int i;
     int line = 0;
     struct logState *st;
     time_t lr_time;
@@ -2666,9 +2665,16 @@ static int readState(const char *stateFilename)
     line++;
 
     while (fgets(buf, sizeof(buf) - 1, f)) {
+        size_t i;
         argv = NULL;
         line++;
         i = strlen(buf);
+        if (i == 0) {
+            message(MESS_ERROR, "line %d not parsable in state file %s\n",
+                    line, stateFilename);
+            fclose(f);
+            return 1;
+        }
         if (buf[i - 1] != '\n') {
             message(MESS_ERROR, "line %d too long in state file %s\n",
                     line, stateFilename);

--- a/logrotate.c
+++ b/logrotate.c
@@ -1500,7 +1500,6 @@ static int prerotateSingleLog(struct logInfo *log, int logNum,
     char dext_str[DATEEXT_LEN];
     char dformat[PATTERN_LEN] = "";
     char dext_pattern[PATTERN_LEN];
-    char *dext;
 
     if (!state->doRotate)
         return 0;
@@ -1587,6 +1586,7 @@ static int prerotateSingleLog(struct logInfo *log, int logNum,
     /* Construct the glob pattern corresponding to the date format */
     dext_str[0] = '\0';
     if (log->dateformat) {
+        char *dext;
         size_t i = 0, j = 0;
         memset(dext_pattern, 0, sizeof(dext_pattern));
         dext = log->dateformat;
@@ -1925,7 +1925,6 @@ static int rotateSingleLog(struct logInfo *log, int logNum,
 {
     int hasErrors = 0;
     struct stat sb;
-    int fd;
     void *savedContext = NULL;
     char *tmpFilename = NULL;
 
@@ -2015,7 +2014,7 @@ static int rotateSingleLog(struct logInfo *log, int logNum,
 
             if (!debug) {
                 if (!hasErrors) {
-                    fd = createOutputFile(log->files[logNum], O_CREAT | O_RDWR,
+                    int fd = createOutputFile(log->files[logNum], O_CREAT | O_RDWR,
                             &sb, prev_acl, have_create_mode);
 #ifdef WITH_ACL
                     if (prev_acl) {

--- a/logrotate.c
+++ b/logrotate.c
@@ -1236,7 +1236,7 @@ static int findNeedRotating(struct logInfo *log, int logNum, int force)
             /* If parent directory doesn't exist, it's not real error
                (unless nomissingok is specified)
                and rotation is not needed */
-            if (errno != ENOENT || (errno == ENOENT && (log->flags & LOG_FLAG_MISSINGOK) == 0)) {
+            if (errno != ENOENT || (log->flags & LOG_FLAG_MISSINGOK) == 0) {
                 message(MESS_ERROR, "stat of %s failed: %s\n", ld,
                         strerror(errno));
                 free(logpath);

--- a/logrotate.c
+++ b/logrotate.c
@@ -1457,8 +1457,15 @@ static int prerotateSingleLog(struct logInfo *log, int logNum,
     message(MESS_DEBUG, "rotating log %s, log->rotateCount is %d\n",
             log->files[logNum], log->rotateCount);
 
-    if (log->compress_ext && (log->flags & LOG_FLAG_COMPRESS))
+    if (log->flags & LOG_FLAG_COMPRESS) {
+        if (!log->compress_ext) {
+            message(MESS_ERROR, "log %s: compression enabled, but compression "
+                "extension is not set\n", log->files[logNum]);
+            return 1;
+        }
+
         compext = log->compress_ext;
+    }
 
     localtime_r(&nowSecs, &now);
     state->lastRotated = now;

--- a/logrotate.c
+++ b/logrotate.c
@@ -120,8 +120,8 @@ static struct compData _compData;
 static int compGlobResult(const void *result1, const void *result2)  {
     struct tm time_tmp;
     time_t t1, t2;
-    const char *r1 = *(const char **)(result1);
-    const char *r2 = *(const char **)(result2);
+    const char *r1 = *(char * const*)(result1);
+    const char *r2 = *(char * const*)(result2);
 
     memset(&time_tmp, 0, sizeof(struct tm));
     strptime(r1 + _compData.prefix_len, _compData.dformat, &time_tmp);

--- a/logrotate.c
+++ b/logrotate.c
@@ -1246,7 +1246,7 @@ static int findNeedRotating(struct logInfo *log, int logNum, int force)
             return 0;
         }
         /* Don't rotate in directories writable by others or group which is not "root"  */
-        if ((sb.st_gid != 0 && sb.st_mode & S_IWGRP) || sb.st_mode & S_IWOTH) {
+        if ((sb.st_gid != 0 && (sb.st_mode & S_IWGRP)) || (sb.st_mode & S_IWOTH)) {
             message(MESS_ERROR, "skipping \"%s\" because parent directory has insecure permissions"
                     " (It's world writable or writable by group which is not \"root\")"
                     " Set \"su\" directive in config file to tell logrotate which user/group"
@@ -1679,8 +1679,8 @@ static int prerotateSingleLog(struct logInfo *log, int logNum,
     }
 
     /* First compress the previous log when necessary */
-    if (log->flags & LOG_FLAG_COMPRESS &&
-            log->flags & LOG_FLAG_DELAYCOMPRESS) {
+    if ((log->flags & LOG_FLAG_COMPRESS) &&
+            (log->flags & LOG_FLAG_DELAYCOMPRESS)) {
         if (log->flags & LOG_FLAG_DATEEXT) {
             /* glob for uncompressed files with our pattern */
             if (asprintf(&glob_pattern, "%s/%s%s%s", rotNames->dirName,
@@ -1988,7 +1988,7 @@ static int rotateSingleLog(struct logInfo *log, int logNum,
             }
         }
 
-        if (!hasErrors && log->flags & LOG_FLAG_CREATE &&
+        if (!hasErrors && (log->flags & LOG_FLAG_CREATE) &&
                 !(log->flags & (LOG_FLAG_COPYTRUNCATE | LOG_FLAG_COPY))) {
             int have_create_mode = 0;
 
@@ -2034,7 +2034,7 @@ static int rotateSingleLog(struct logInfo *log, int logNum,
         restoreSecCtx(&savedContext);
 
         if (!hasErrors
-                && log->flags & (LOG_FLAG_COPYTRUNCATE | LOG_FLAG_COPY)
+                && (log->flags & (LOG_FLAG_COPYTRUNCATE | LOG_FLAG_COPY))
                 && !(log->flags & LOG_FLAG_TMPFILENAME)) {
             hasErrors = copyTruncate(log->files[logNum], rotNames->finalName,
                                      &state->sb, log->flags, !log->rotateCount);
@@ -2061,7 +2061,7 @@ static int postrotateSingleLog(struct logInfo *log, int logNum,
         return 0;
     }
 
-    if (!hasErrors && log->flags & LOG_FLAG_TMPFILENAME) {
+    if (!hasErrors && (log->flags & LOG_FLAG_TMPFILENAME)) {
         char *tmpFilename = NULL;
         if (asprintf(&tmpFilename, "%s%s", log->files[logNum], ".tmp") < 0) {
             message(MESS_FATAL, "could not allocate tmpFilename memory\n");
@@ -2251,7 +2251,7 @@ static int rotateLogSet(struct logInfo *log, int force)
                         "since no logs will be rotated\n");
             } else {
                 message(MESS_DEBUG, "running prerotate script\n");
-                if (runScript(log, log->flags & LOG_FLAG_SHAREDSCRIPTS ? log->pattern : log->files[j], NULL, log->pre)) {
+                if (runScript(log, (log->flags & LOG_FLAG_SHAREDSCRIPTS) ? log->pattern : log->files[j], NULL, log->pre)) {
                     if (log->flags & LOG_FLAG_SHAREDSCRIPTS)
                         message(MESS_ERROR,
                                 "error running shared prerotate script "

--- a/logrotate.c
+++ b/logrotate.c
@@ -450,6 +450,7 @@ static struct logState *findState(const char *fn)
 static int runScript(struct logInfo *log, char *logfn, char *logrotfn, char *script)
 {
     int rc;
+    pid_t pid;
 
     if (debug) {
         message(MESS_DEBUG, "running script with args %s %s: \"%s\"\n",
@@ -457,7 +458,14 @@ static int runScript(struct logInfo *log, char *logfn, char *logrotfn, char *scr
         return 0;
     }
 
-    if (!fork()) {
+    pid = fork();
+
+    if (pid == -1) {
+        message(MESS_ERROR, "can not fork: %s\n", strerror(errno));
+        return 1;
+    }
+
+    if (pid == 0) {
         if (log->flags & LOG_FLAG_SU) {
             if (switch_user_back_permanently() != 0) {
                 exit(1);
@@ -599,6 +607,7 @@ static int shred_file(int fd, char *filename, struct logInfo *log)
     const char **fullCommand;
     int id = 0;
     int status;
+    pid_t pid;
 
     if (log->preremove) {
         message(MESS_DEBUG, "running preremove script\n");
@@ -636,7 +645,14 @@ static int shred_file(int fd, char *filename, struct logInfo *log)
     fullCommand[id++] = "-";
     fullCommand[id++] = NULL;
 
-    if (!fork()) {
+    pid = fork();
+
+    if (pid == -1) {
+        message(MESS_ERROR, "can not fork: %s\n", strerror(errno));
+        return 1;
+    }
+
+    if (pid == 0) {
         movefd(fd, STDOUT_FILENO);
 
         if (switch_user_permanently(log) != 0) {
@@ -728,6 +744,7 @@ static int compressLogFile(char *name, struct logInfo *log, struct stat *sb)
     char buff[4092];
     int error_printed = 0;
     void *prevCtx;
+    pid_t pid;
 
     message(MESS_DEBUG, "compressing log with: %s\n", log->compress_prog);
     if (debug)
@@ -789,7 +806,18 @@ static int compressLogFile(char *name, struct logInfo *log, struct stat *sb)
         return 1;
     }
 
-    if (!fork()) {
+    pid = fork();
+
+    if (pid == -1) {
+        message(MESS_ERROR, "can not fork: %s\n", strerror(errno));
+        close(inFile);
+        close(outFile);
+        close(compressPipe[1]);
+        close(compressPipe[0]);
+        return 1;
+    }
+
+    if (pid == 0) {
         /* close read end of pipe in the child process */
         close(compressPipe[0]);
 
@@ -865,7 +893,18 @@ static int mailLog(struct logInfo *log, char *logFile, const char *mailComm,
             close(mailInput);
             return 1;
         }
-        if (!(uncompressChild = fork())) {
+
+        uncompressChild = fork();
+
+        if (uncompressChild == -1) {
+            message(MESS_ERROR, "can not fork: %s \n", strerror(errno));
+            close(mailInput);
+            close(uncompressPipe[1]);
+            close(uncompressPipe[0]);
+            return 1;
+        }
+
+        if (uncompressChild == 0) {
             /* uncompress child */
 
             /* close read end of pipe in the child process */
@@ -887,7 +926,15 @@ static int mailLog(struct logInfo *log, char *logFile, const char *mailComm,
         close(uncompressPipe[1]);
     }
 
-    if (!(mailChild = fork())) {
+    mailChild = fork();
+
+    if (mailChild == -1) {
+        message(MESS_ERROR, "can not fork: %s\n", strerror(errno));
+        close(mailInput);
+        return 1;
+    }
+
+    if (mailChild == 0) {
         movefd(mailInput, STDIN_FILENO);
         close(STDOUT_FILENO);
 

--- a/logrotate.c
+++ b/logrotate.c
@@ -2080,7 +2080,7 @@ static int rotateLogSet(struct logInfo *log, int force)
                 message(MESS_DEBUG, "%jd bytes ", (intmax_t)log->threshold);
                 break;
             default:
-                message(MESS_DEBUG, "rotateLogSet() does not have case for: %u ",
+                message(MESS_FATAL, "rotateLogSet() does not have case for: %u ",
                         (unsigned) log->criterium);
         }
     }

--- a/logrotate.c
+++ b/logrotate.c
@@ -187,6 +187,12 @@ static int switch_user_permanently(const struct logInfo *log) {
                 (unsigned) user, (unsigned) group, strerror(errno));
         return 1;
     }
+
+    if (setuid(0) != -1) {
+        message(MESS_ERROR, "failed to switch user permanently, able to switch back\n");
+        return 1;
+    }
+
     return 0;
 }
 

--- a/logrotate.c
+++ b/logrotate.c
@@ -2183,7 +2183,7 @@ static int rotateLogSet(struct logInfo *log, int force)
 
         if (log->pre
                 && (!(
-                        ((logHasErrors[j] || !state[j]->doRotate) && !(log->flags & LOG_FLAG_SHAREDSCRIPTS))
+                        (!(log->flags & LOG_FLAG_SHAREDSCRIPTS) && (logHasErrors[j] || !state[j]->doRotate))
                         || (hasErrors && (log->flags & LOG_FLAG_SHAREDSCRIPTS))
                      ))
            ) {
@@ -2221,7 +2221,7 @@ static int rotateLogSet(struct logInfo *log, int force)
 
         if (log->post
                 && (!(
-                        ((logHasErrors[j] || !state[j]->doRotate) && !(log->flags & LOG_FLAG_SHAREDSCRIPTS))
+                        (!(log->flags & LOG_FLAG_SHAREDSCRIPTS) && (logHasErrors[j] || !state[j]->doRotate))
                         || (hasErrors && (log->flags & LOG_FLAG_SHAREDSCRIPTS))
                      ))
            ) {

--- a/logrotate.c
+++ b/logrotate.c
@@ -1727,8 +1727,7 @@ static int prerotateSingleLog(struct logInfo *log, int logNum,
                 if (asprintf(&oldName, "%s", (globResult.gl_pathv)[mail_out]) < 0) {
                     message(MESS_FATAL, "could not allocate mailout memory\n");
                 }
-                rotNames->disposeName = malloc(strlen(oldName)+1);
-                strcpy(rotNames->disposeName, oldName);
+                rotNames->disposeName = strdup(oldName);
                 free(oldName);
             } else {
                 free(rotNames->disposeName);

--- a/logrotate.h
+++ b/logrotate.h
@@ -97,6 +97,12 @@ extern int debug;
 int switch_user(uid_t user, gid_t group);
 int switch_user_back(void);
 int readAllConfigPaths(const char **paths);
+
+enum check_result { CHK_SECURE = 0, CHK_ERROR = 1, CHK_NOTDIR, CHK_FAIL_OWNER, CHK_FAIL_GROUP, CHK_FAIL_OTHER };
+int check_dir_secure(const char *fullpath);
+int check_file_in_secure_dir(const char *filepath);
+int check_path_secure(const char *path);
+
 #if !defined(asprintf) && !defined(_FORTIFY_SOURCE)
 int asprintf(char **string_ptr, const char *format, ...);
 #endif


### PR DESCRIPTION
- Silence/fix several issues/warnings from clang/scan-build/cppcheck/coverity
- Consistently check for memory allocation failures
- Tighten state and config file handling