### PR TITLE
state file handling

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -2632,8 +2632,8 @@ static int writeState(const char *stateFilename)
         if (rename(tmpFilename, stateFilename)) {
             unlink(tmpFilename);
             error = 1;
-            message(MESS_ERROR, "error renaming temp state file %s\n",
-                    tmpFilename);
+            message(MESS_ERROR, "error renaming temp state file %s to %s\n",
+                    tmpFilename, stateFilename);
         }
     }
     else {

--- a/logrotate.c
+++ b/logrotate.c
@@ -2451,7 +2451,14 @@ static int writeState(const char *stateFilename)
     strcpy(tmpFilename, stateFilename);
     strcat(tmpFilename, ".tmp");
     /* Remove possible tmp state file from previous run */
-    unlink(tmpFilename);
+    error = unlink(tmpFilename);
+    if (error == -1 && errno != ENOENT) {
+        message(MESS_ERROR, "error removing old temporary state file %s: %s\n",
+                tmpFilename, strerror(errno));
+        free(tmpFilename);
+        return 1;
+    }
+    error = 0;
 
     fdcurr = open(stateFilename, O_RDONLY);
     if (fdcurr == -1) {

--- a/logrotate.c
+++ b/logrotate.c
@@ -2637,7 +2637,6 @@ static int writeState(const char *stateFilename)
         }
     }
     else {
-        unlink(tmpFilename);
         if (errno)
             message(MESS_ERROR, "error creating temp state file %s: %s\n",
                     tmpFilename, strerror(errno));
@@ -2645,6 +2644,7 @@ static int writeState(const char *stateFilename)
             message(MESS_ERROR, "error creating temp state file %s%s\n",
                     tmpFilename, error == ENOMEM ?
                     ": Insufficient storage space is available." : "" );
+        unlink(tmpFilename);
     }
     free(tmpFilename);
     return error;


### PR DESCRIPTION
* move creation of stub state file to writeState
  Currently readState() creates a stub state file if none exists already.
  This stub file is only used later in writeState() to compute the file attributes for the final state file.

  Move the creation from readState() to writeState() to merge this logic.

  Also use the exclusive flag to create the stub file, to avoid a theoretical toctou race condition.
* readState: open state file only once
* writeState: fail if old temporary state file can not be removed
* writeState: improve error message
* writeState: delay unlink to not alter errno