### PR TITLE
split declaration and definition of queue variable

### DIFF
--- a/config.c
+++ b/config.c
@@ -28,6 +28,8 @@
 #include "log.h"
 #include "logrotate.h"
 
+struct logInfoHead logs;
+
 #if !defined(GLOB_ABORTED) && defined(GLOB_ABEND)
 #define GLOB_ABORTED GLOB_ABEND
 #endif

--- a/logrotate.h
+++ b/logrotate.h
@@ -89,7 +89,8 @@ struct logInfo {
     TAILQ_ENTRY(logInfo) list;
 };
 
-TAILQ_HEAD(logInfoHead, logInfo) logs;
+TAILQ_HEAD(logInfoHead, logInfo);
+extern struct logInfoHead logs;
 
 extern int numLogs;
 extern int debug;


### PR DESCRIPTION
Support compilation with -fno-common flag, which is the default for GCC 10.

Fixes: #288