### PR TITLE
logrotate.service: add systemd hardening options

### DIFF
--- a/examples/logrotate.service
+++ b/examples/logrotate.service
@@ -17,11 +17,15 @@ IOSchedulingPriority=7
 #  details: https://www.freedesktop.org/software/systemd/man/systemd.exec.html
 #  no ProtectHome for userdir logs
 #  no PrivateNetwork for mail deliviery
+#  no NoNewPrivileges for third party rotate scripts
+LockPersonality=true
 MemoryDenyWriteExecute=true
 PrivateDevices=true
 PrivateTmp=true
 ProtectControlGroups=true
+ProtectKernelLogs=true
 ProtectKernelModules=true
 ProtectKernelTunables=true
 ProtectSystem=full
+RestrictNamespaces=true
 RestrictRealtime=true


### PR DESCRIPTION
+ RestrictNamespaces : prohibit namespacing
+ LockPersonality : prohibit usage of personality(2)
+ ProtectKernelLogs : prohibit access to the kernel ring buffer (syslog(2) (NOT syslog(3)), /dev/kmsg and /proc/kmsg)