### PR TITLE
config.c: fixing the alloca.h include for OpenBSD

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -1,6 +1,6 @@
 #include "queue.h"
 /* alloca() is defined in stdlib.h in NetBSD */
-#if !defined(__NetBSD__) && !defined(__FreeBSD__)
+#if !defined(__NetBSD__) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
 #include <alloca.h>
 #endif
 #include <limits.h>


### PR DESCRIPTION
Currently working on packaging logrotate for OpenBSD (via ports).
As any other *BSD system, the alloca() function is defined in
stdlib.h, so no need to include alloca.h (does not exist anyway).