### PR TITLE
Delete old logs hit by maxage regardless of dateext (Fix: #301)

### DIFF
--- a/logrotate.8.in
+++ b/logrotate.8.in
@@ -197,8 +197,9 @@ These directives may be included in a \fBlogrotate\fR configuration file:
 \fBrotate \fIcount\fR
 Log files are rotated \fIcount\fR times before being removed or mailed to the
 address specified in a \fBmail\fR directive.  If \fIcount\fR is 0, old versions
-are removed rather than rotated.  If \fIcount\fR is -1, old logs are not removed
-at all (use with caution, may waste performance and disk space). Default is 0.
+are removed rather than rotated.  If \fIcount\fR is \-1, old logs are not
+removed at all, except they are affected by \fBmaxage\fR (use with caution, may
+waste performance and disk space).  Default is 0.
 
 .TP
 \fBolddir \fIdirectory\fR
@@ -293,9 +294,10 @@ Do not rotate logs which are less than <count> days old.
 
 .TP
 \fBmaxage\fR \fIcount\fR
-Remove rotated logs older than <count> days. The age is only checked
-if the logfile is to be rotated.  The files are mailed to the
-configured address if \fBmaillast\fR and \fBmail\fR are configured.
+Remove rotated logs older than <count> days.  The age is only checked
+if the logfile is to be rotated.  \fBrotate \-1\fR does not hinder removal.
+The files are mailed to the configured address if \fBmaillast\fR and
+\fBmail\fR are configured.
 
 .TP
 \fBminsize\fR \fIsize\fR

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -83,6 +83,8 @@ TEST_CASES = \
 	test-0082.sh \
 	test-0083.sh \
 	test-0084.sh \
+	test-0085.sh \
+	test-0086.sh \
 	test-0100.sh \
 	test-0101.sh
 

--- a/test/test-0085.sh
+++ b/test/test-0085.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+. ./test-common.sh
+
+cleanup 85
+
+# ------------------------------- Test 85 ------------------------------------
+preptest test.log 85 0
+
+$RLR test-config.85 -f
+
+checkoutput <<EOF
+test.log 0
+test.log.1 0 zero
+EOF
+
+# Set log modification time to some date in the past
+touch -t 200001010000 test.log.1
+
+echo "content" >> test.log
+
+$RLR test-config.85 -f
+
+# maxage should remove this file
+if [ -f test.log.2 ]; then
+    echo "log not removed" >&2
+    exit 3
+fi
+
+checkoutput <<EOF
+test.log 0
+test.log.1 0 content
+EOF

--- a/test/test-0086.sh
+++ b/test/test-0086.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+. ./test-common.sh
+
+cleanup 86
+
+# ------------------------------- Test 86 ------------------------------------
+preptest test.log 86 0
+
+$RLR test-config.86 -f
+
+checkoutput <<EOF
+test.log 0
+test.log-$(date +%Y%m%d) 0 zero
+EOF
+
+LOGFILE="test.log-$(date +%Y%m%d)"
+
+# Set log modification time to some date in the past
+touch -t 200001010000 $LOGFILE
+mv $LOGFILE test.log-20000101
+
+echo "content" >> test.log
+
+$RLR test-config.86 -f
+
+# maxage should remove this file
+if [ -f test.log-20000101 ]; then
+    echo "log not removed" >&2
+    exit 3
+fi
+
+checkoutput <<EOF
+test.log 0
+test.log-$(date +%Y%m%d) 0 content
+EOF

--- a/test/test-config.85.in
+++ b/test/test-config.85.in
@@ -1,0 +1,6 @@
+create
+
+&DIR&/test.log {
+    rotate -1
+    maxage 1
+}

--- a/test/test-config.86.in
+++ b/test/test-config.86.in
@@ -1,0 +1,7 @@
+create
+
+&DIR&/test.log {
+    rotate -1
+    maxage 1
+    dateext
+}


### PR DESCRIPTION
Currently old logs hit by `maxage` are only removed if `dateext` is used.
Unify the behavior to remove them.

Document the relation between `maxage` and `rotate -1` in the manpage.

Fixes: #301