### PR TITLE
Clang 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,22 +109,22 @@ matrix:
       addons:
         apt:
           sources:
-            - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main'
+            - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main'
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
           packages:
-            - clang-9
-      env: COMPILER=clang-9 CFLAGS='-O1 -g -fsanitize=address -fno-omit-frame-pointer -fsanitize=undefined -fsanitize=nullability -fsanitize=implicit-conversion -fsanitize=integer' LSAN_OPTIONS=suppressions=test/leak_san_supress.txt
+            - clang-10
+      env: COMPILER=clang-10 CFLAGS='-O1 -g -fsanitize=address -fno-omit-frame-pointer -fsanitize=undefined -fsanitize=nullability -fsanitize=implicit-conversion -fsanitize=integer' ASAN_OPTIONS=detect_stack_use_after_return=1 LSAN_OPTIONS=suppressions=test/leak_san_supress.txt
     - compiler: clang
       dist: bionic
       addons:
         apt:
           sources:
-            - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main'
+            - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main'
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
           packages:
-            - clang-9
-            - clang-tools-9
-      env: COMPILER=scan-build-9
+            - clang-10
+            - clang-tools-10
+      env: COMPILER=scan-build-10
 
 install:
   - sudo add-apt-repository ppa:dns/gnu -y

--- a/config.c
+++ b/config.c
@@ -998,7 +998,7 @@ static int readConfigFile(const char *configFile, struct logInfo *defConfig)
             return 0;
         }
 
-        if (sb.st_uid != ROOT_UID && (pw == NULL ||
+        if (sb.st_uid != ROOT_UID && (
                     sb.st_uid != pw->pw_uid ||
                     pw->pw_uid != ROOT_UID)) {
             message(MESS_ERROR,

--- a/config.c
+++ b/config.c
@@ -925,7 +925,6 @@ static int readConfigFile(const char *configFile, struct logInfo *defConfig)
     char **scriptDest = NULL;
     struct logInfo *newlog = defConfig;
     char *start, *chptr;
-    struct passwd *pw;
     struct stat sb;
     int state = STATE_DEFAULT;
     int logerror = 0;
@@ -967,7 +966,7 @@ static int readConfigFile(const char *configFile, struct logInfo *defConfig)
         return 0;
     }
 
-    if (!(pw = getpwuid(getuid()))) {
+    if (!getpwuid(getuid())) {
         message(MESS_ERROR, "Cannot find logrotate UID (%d) in passwd file: %s\n",
                 getuid(), strerror(errno));
         close(fd);
@@ -975,6 +974,8 @@ static int readConfigFile(const char *configFile, struct logInfo *defConfig)
     }
 
     if (getuid() == ROOT_UID) {
+        struct passwd *pw;
+
         if ((sb.st_mode & 07533) != 0400) {
             message(MESS_DEBUG,
                     "Potentially dangerous mode on %s: 0%o\n",

--- a/config.c
+++ b/config.c
@@ -968,7 +968,8 @@ static int readConfigFile(const char *configFile, struct logInfo *defConfig)
     }
 
     if (!(pw = getpwuid(getuid()))) {
-        message(MESS_ERROR, "Logrotate UID is not in passwd file.\n");
+        message(MESS_ERROR, "Cannot find logrotate UID (%d) in passwd file: %s\n",
+                getuid(), strerror(errno));
         close(fd);
         return 1;
     }


### PR DESCRIPTION
* Bump clang for analyser and sanitizer run to version 10
* Resolve clang-analyzer warning:
```
config.c:970:11: warning: Although the value stored to 'pw' is used in the enclosing expression, the value is never actually read from 'pw'
    if (!(pw = getpwuid(getuid()))) {
          ^    ~~~~~~~~~~~~~~~~~~
```

There is on thing bothering me: the condition in config.c:readConfigFile()
https://github.com/logrotate/logrotate/blob/184d07687f3b6870ef6d6da454536c6bfa12f076/config.c#L999-L1007

0. `pw` can't be `NULL`, that's easy (see 4th commit)
1. so the conditions simplifies to:
`sb.st_uid != ROOT_UID && (sb.st_uid != pw->pw_uid || pw->pw_uid != ROOT_UID)`

If the first `&&` argument is `true` (e.g. `sb.st_uid` differs from `ROOT_UID`), the second argument can not be `false`: `pw->pw_uid` can not be equal to `sb.st_uid` and simultaneously equal to `ROOT_UID` (by the first `&&` argument)

So basically the current check collapses to `sb.st_uid != ROOT_UID`, should it be `sb.st_uid != ROOT_UID && sb.st_uid != pw->pw_uid`??

I think commit f9c16896d15916eeccb2ce950dd1313deb4f512c was not quite accurate.