### PR TITLE
switch_user_permanently: skip switchback check if switched to root

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -2317,6 +2317,9 @@ static int rotateLogSet(const struct logInfo *log, int force)
 
     if (state == NULL || rotNames == NULL) {
         message_OOM();
+        if (log->flags & LOG_FLAG_SU) {
+             switch_user_back();
+        }
         free(rotNames);
         free(state);
         free(logHasErrors);
@@ -2337,6 +2340,9 @@ static int rotateLogSet(const struct logInfo *log, int force)
             rotNames[i] = malloc(sizeof(struct logNames));
             if (rotNames[i] == NULL) {
                 message_OOM();
+                if (log->flags & LOG_FLAG_SU) {
+                    switch_user_back();
+                }
                 free(rotNames);
                 free(state);
                 free(logHasErrors);

--- a/logrotate.c
+++ b/logrotate.c
@@ -183,7 +183,7 @@ static int switch_user_permanently(const struct logInfo *log) {
         return 1;
     }
 
-    if (setuid(ROOT_UID) != -1) {
+    if (user != ROOT_UID && setuid(ROOT_UID) != -1) {
         message(MESS_ERROR, "failed to switch user permanently, able to switch back\n");
         return 1;
     }


### PR DESCRIPTION
*  switch_user_permanently: skip switchback check if switched to root
   Allow switching only the real group (not the user) with a configuration
   like `su root somegroup`.
   E.g. mailman uses `su root list`, which currently fails with:
       `error: failed to switch user permanently, able to switch back`
      `error: failed to compress log /var/log/mailman/qrunner.1`

*  switch_user_permanently: add sanity check that effective ids match configuration specified ones

*  switch_user*: improve debug logging
   Print pid to distinguish processes.
   Print previous effective ids.

* rotateLogSet: call switch_user_back on early return 


