### PR TITLE
Do not check for null input in custom strndup implementation

### DIFF
--- a/config.c
+++ b/config.c
@@ -85,9 +85,6 @@ char *strndup(const char *s, size_t n)
     size_t nAvail;
     char *p;
 
-    if(!s)
-        return NULL;
-
     /* min() */
     nAvail = strlen(s) + 1;
     if ( (n + 1) < nAvail)

--- a/logrotate.h
+++ b/logrotate.h
@@ -98,6 +98,10 @@ int readAllConfigPaths(const char **paths);
 #if !defined(asprintf) && !defined(_FORTIFY_SOURCE)
 int asprintf(char **string_ptr, const char *format, ...);
 #endif
+#if !defined(HAVE_STRNDUP)
+__attribute__((nonnull))
+char *strndup(const char *s, size_t n);
+#endif
 
 #endif
 


### PR DESCRIPTION
The standard strndup() does expect a string (not a NULL) value.

The extra check breaks gcc-10 with lto:

    config.c: In function ‘strndup’:
    config.c:88:7: error: ‘nonnull’ argument ‘s’ compared to NULL [-Werror=nonnull-compare]
       88 |     if(!s)
          |       ^
    cc1: all warnings being treated as errors