### PR TITLE
logrotate.conf: mention to order global options first

### DIFF
--- a/examples/logrotate.conf
+++ b/examples/logrotate.conf
@@ -1,4 +1,7 @@
 # see "man logrotate" for details
+
+# global options do not affect preceding include directives
+
 # rotate log files weekly
 weekly
 

--- a/logrotate.8.in
+++ b/logrotate.8.in
@@ -116,7 +116,8 @@ Display version information.
 from the series of configuration files specified on the command line.  Each
 configuration file can set global options (local definitions override
 global ones, and later definitions override earlier ones) and specify
-logfiles to rotate.  A simple configuration file looks like this:
+logfiles to rotate.  Global options do not affect preceding include
+directives.  A simple configuration file looks like this:
 
 .nf
 .ta +8n


### PR DESCRIPTION
Options defined after an include directive won't apply to that statement.

Closes: #321