### PR TITLE
Allow to pass a home-relative path to include

### DIFF
--- a/logrotate.8.in
+++ b/logrotate.8.in
@@ -590,8 +590,10 @@ before processing of the including file continues.  The only files
 which are ignored are files which are not regular files (such as
 directories and named pipes) and files whose names end with one of
 the taboo extensions or patterns, as specified by the \fBtabooext\fR
-or \fBtaboopat\fR directives, respectively.  For security reasons
-configuration files must not be group-writable nor world-writable.
+or \fBtaboopat\fR directives, respectively.  The given path may
+start with \fB~/\fR to make it relative to the home directory of
+the executing user.  For security reasons configuration files must
+not be group-writable nor world-writable.
 
 .SS Scripts
 


### PR DESCRIPTION
Accept a path with leading "~/" in include directives and replace with the environment variable ${HOME} (if existent).