### PR TITLE
configure.ac: compile with -Wdeclaration-after-statement

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -169,7 +169,19 @@ AC_SUBST(ROOT_UID)
 AC_CHECK_FUNCS([asprintf madvise qsort strndup strptime utimensat vsyslog])
 AC_CONFIG_HEADERS([config.h])
 
-AM_CFLAGS="-Wall -Wconversion -Wextra -Wmissing-format-attribute -Wmissing-noreturn -Wpointer-arith -Wshadow -Wstrict-prototypes -Wundef -Wunused -Wwrite-strings"
+AM_CFLAGS="\
+ -Wall\
+ -Wconversion\
+ -Wextra\
+ -Wmissing-format-attribute\
+ -Wmissing-noreturn\
+ -Wpointer-arith\
+ -Wshadow\
+ -Wstrict-prototypes\
+ -Wundef\
+ -Wunused\
+ -Wwrite-strings"
+
 AC_ARG_ENABLE([werror],
         [AS_HELP_STRING([--enable-werror],
                 [Treat warnings as errors (default: warnings are not errors)])],

--- a/configure.ac
+++ b/configure.ac
@@ -172,6 +172,7 @@ AC_CONFIG_HEADERS([config.h])
 AM_CFLAGS="\
  -Wall\
  -Wconversion\
+ -Wdeclaration-after-statement\
  -Wextra\
  -Wmissing-format-attribute\
  -Wmissing-noreturn\


### PR DESCRIPTION
... to make sure we keep the code ISO C90 compliant