### PR TITLE
Add .bak extension to default taboo list

### DIFF
--- a/config.c
+++ b/config.c
@@ -125,6 +125,7 @@ enum {
 
 static const char *defTabooExts[] = {
     ",v",
+    ".bak",
     ".cfsaved",
     ".disabled",
     ".dpkg-bak",


### PR DESCRIPTION
Suggested at https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=945097