### PR TITLE
Add fallback to resolve uids and gids numerically

### DIFF
--- a/config.c
+++ b/config.c
@@ -247,37 +247,67 @@ static char *readPath(const char *configFile, int lineNum, const char *key,
 /* set *pUid to UID of the given user, return non-zero on failure */
 static int resolveUid(const char *userName, uid_t *pUid)
 {
-    struct passwd *pw;
+    const struct passwd *pw;
+    char *endptr;
+    unsigned long int parsed_uid;
+
 #ifdef __CYGWIN__
     if (strcmp(userName, "root") == 0) {
         *pUid = 0;
         return 0;
     }
 #endif
+
     pw = getpwnam(userName);
-    if (!pw)
-        return -1;
-    *pUid = pw->pw_uid;
-    endpwent();
-    return 0;
+    if (pw) {
+        *pUid = pw->pw_uid;
+        return 0;
+    }
+
+    parsed_uid = strtoul(userName, &endptr, 10);
+    if (userName[0] != '\0' &&
+        *endptr == '\0' &&
+        parsed_uid < INT_MAX && /* parsed_uid != ULONG_MAX && */
+        getpwuid((uid_t)parsed_uid) != NULL) {
+
+        *pUid = (uid_t)parsed_uid;
+        return 0;
+    }
+
+    return -1;
 }
 
 /* set *pGid to GID of the given group, return non-zero on failure */
 static int resolveGid(const char *groupName, gid_t *pGid)
 {
-    struct group *gr;
+    const struct group *gr;
+    char *endptr;
+    unsigned long int parsed_gid;
+
 #ifdef __CYGWIN__
     if (strcmp(groupName, "root") == 0) {
         *pGid = 0;
         return 0;
     }
 #endif
+
     gr = getgrnam(groupName);
-    if (!gr)
-        return -1;
-    *pGid = gr->gr_gid;
-    endgrent();
-    return 0;
+    if (gr) {
+        *pGid = gr->gr_gid;
+        return 0;
+    }
+
+    parsed_gid = strtoul(groupName, &endptr, 10);
+    if (groupName[0] != '\0' &&
+        *endptr == '\0' &&
+        parsed_gid < INT_MAX && /* parsed_gid != ULONG_MAX && */
+        getgrgid((gid_t)parsed_gid) != NULL) {
+
+        *pGid = (gid_t)parsed_gid;
+        return 0;
+    }
+
+    return -1;
 }
 
 static int readModeUidGid(const char *configFile, int lineNum, char *key,

--- a/logrotate.8.in
+++ b/logrotate.8.in
@@ -238,8 +238,9 @@ overrides the \fBolddir\fR option).
 .TP
 \fBsu \fIuser\fR \fIgroup\fR
 Rotate log files set under this user and group instead of using default
-user/group (usually root).  \fIuser\fR specifies the user name used for
-rotation and \fIgroup\fR specifies the group used for rotation.  If the
+user/group (usually root).  \fIuser\fR specifies the user used for
+rotation and \fIgroup\fR specifies the group used for rotation (see the
+section \fBUSER AND GROUP\fR for details).  If the
 user/group you specify here does not have sufficient privilege to make
 files with the ownership you've specified in a \fBcreate\fR directive,
 it will cause an error.  If \fBlogrotate\fR runs with root privileges, it is
@@ -378,9 +379,10 @@ is replaced.  At startup, the taboo pattern list is empty.
 Immediately after rotation (before the \fBpostrotate\fR script is run)
 the log file is created (with the same name as the log file just rotated).
 \fImode\fR specifies the mode for the log file in octal (the same
-as \fBchmod\fR(2)), \fIowner\fR specifies the user name who will own the
+as \fBchmod\fR(2)), \fIowner\fR specifies the user who will own the
 log file, and \fIgroup\fR specifies the group the log file will belong
-to.  Any of the log file attributes may be omitted, in which case those
+to (see the section \fBUSER AND GROUP\fR for details).
+Any of the log file attributes may be omitted, in which case those
 attributes for the new file will use the same values as the original log
 file for the omitted attributes.  This option can be disabled using the
 \fBnocreate\fR option.
@@ -393,9 +395,10 @@ New log files are not created (this overrides the \fBcreate\fR option).
 \fBcreateolddir \fImode\fR \fIowner\fR \fIgroup\fR
 If the directory specified by \fBolddir\fR directive does not exist, it is
 created. \fImode\fR specifies the mode for the \fBolddir\fR directory
-in octal (the same as \fBchmod\fR(2)), \fIowner\fR specifies the user name
+in octal (the same as \fBchmod\fR(2)), \fIowner\fR specifies the user
 who will own the \fBolddir\fR directory, and \fIgroup\fR specifies the group
-the \fBolddir\fR directory will belong to.  This option can be disabled using
+the \fBolddir\fR directory will belong to (see the section \fBUSER AND GROUP
+\fR for details).  This option can be disabled using
 the \fBnocreateolddir\fR option.
 
 .TP
@@ -711,6 +714,11 @@ stderr, stdout, the current directory, the environment, and the umask.
 Scripts are run as the invoking user and group, irrespective of any \fBsu\fR
 directive.  If the \fB\-\-log\fR flag was specified, file descriptor 3 is the
 log file.
+
+.SH USER AND GROUP
+
+User and group identifiers are resolved first by trying the textual
+representation and, in case it fails, afterwards by the numeric value.
 
 .SH FILES
 


### PR DESCRIPTION
Allow uids and gids to be specified numerically, but only as a fallback
to retain backward compatibility.

Closes: #217