### PR TITLE
Add check that copytruncate and rotate 0 does not keep a rotated log file

### DIFF
--- a/test/test-0073.sh
+++ b/test/test-0073.sh
@@ -6,11 +6,19 @@ cleanup 73
 
 # ------------------------------- Test 73 ------------------------------------
 # make sure that 'copy' and 'copytruncate' work together
-preptest test.log 73 2
+preptest test_copy.log 73 2
+# make sure that 'rotate 0' and 'copytruncate' work together
+preptest test_rotate.log 73 0
 
 $RLR test-config.73 --force
 
 checkoutput <<EOF
-test.log 0
-test.log.1 0 zero
+test_copy.log 0
+test_copy.log.1 0 zero
+test_rotate.log 0
 EOF
+
+if [ -f test_rotate.log.1 ]; then
+    echo "rotate 0 and copytruncate keep a rotated log file"
+    exit 3
+fi

--- a/test/test-config.73.in
+++ b/test/test-config.73.in
@@ -1,5 +1,10 @@
-&DIR&/test*.log {
+&DIR&/test_copy.log {
     copy
     copytruncate
     rotate 1
+}
+
+&DIR&/test_rotate.log {
+    copytruncate
+    rotate 0
 }


### PR DESCRIPTION
Fixed in version 3.15