### PR TITLE
logrotate.8: do not say that sharedscripts implies create

### DIFF
--- a/logrotate.8.in
+++ b/logrotate.8.in
@@ -617,7 +617,7 @@ and whole pattern is passed to them.
 However, if none of the logs in the pattern require rotating, the scripts
 will not be run at all.  If the scripts exit with error (or any log fails to
 rotate), the remaining actions will not be executed for any logs.  This option
-overrides the \fBnosharedscripts\fR option and implies \fBcreate\fR option.
+overrides the \fBnosharedscripts\fR option.
 
 .TP
 \fBnosharedscripts\fR


### PR DESCRIPTION
It is unclear and otherwise undocumented why this would be the case.

Fixes: https://github.com/logrotate/logrotate/issues/336
Closes: https://github.com/logrotate/logrotate/pull/340