### PR TITLE
make `delaycompress` not to fail with `rotate 0`

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -2076,7 +2076,9 @@ static int rotateSingleLog(const struct logInfo *log, unsigned logNum,
 
             if (!log->rotateCount) {
                 const char *ext = "";
-                if (log->compress_ext && (log->flags & LOG_FLAG_COMPRESS))
+                if (log->compress_ext
+                        && (log->flags & LOG_FLAG_COMPRESS)
+                        && !(log->flags & LOG_FLAG_DELAYCOMPRESS))
                     ext = log->compress_ext;
 
                 free(rotNames->disposeName);

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -86,6 +86,7 @@ TEST_CASES = \
 	test-0085.sh \
 	test-0086.sh \
 	test-0087.sh \
+	test-0088.sh \
 	test-0100.sh \
 	test-0101.sh
 

--- a/test/test-0088.sh
+++ b/test/test-0088.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+. ./test-common.sh
+
+# check that `delaycompress` does not fail with `rotate 0`
+cleanup 88
+
+preptest test.log 88 0
+
+$RLR -fv test-config.88 2> stderr || exit $?
+
+if grep 'error:.*No such file or directory' stderr; then
+    exit 7
+else
+    exit 0
+fi

--- a/test/test-config.88.in
+++ b/test/test-config.88.in
@@ -1,0 +1,6 @@
+&DIR&/test.log
+{
+    rotate 0
+    compress
+    delaycompress
+}


### PR DESCRIPTION
It does not make much sense to use these configuration directives
together.  Nevertheless it may happen when `delaycompress` is added
to `/etc/logrotate.conf` while a separate package uses `rotate 0` in
its own configuration file in `/etc/logrotate.d/`.

Bug: https://bugs.gentoo.org/689558
Fixes: https://github.com/logrotate/logrotate/issues/341
Closes: https://github.com/logrotate/logrotate/pull/343