### PR TITLE
use getenv on macOS and BSD

### DIFF
--- a/config.c
+++ b/config.c
@@ -45,6 +45,10 @@ struct logInfoHead logs;
 #include "asprintf.c"
 #endif
 
+#if !defined(HAVE_SECURE_GETENV)
+#define secure_getenv getenv
+#endif
+
 #if !defined(HAVE_ASPRINTF) && !defined(_FORTIFY_SOURCE)
 #include <stdarg.h>
 

--- a/configure.ac
+++ b/configure.ac
@@ -166,7 +166,7 @@ AC_SUBST(COMPRESS_EXT)
 AC_DEFINE_UNQUOTED([ROOT_UID], [0], [Root user-id.])
 AC_SUBST(ROOT_UID)
 
-AC_CHECK_FUNCS([asprintf madvise qsort strndup strptime utimensat vsyslog])
+AC_CHECK_FUNCS([asprintf madvise qsort secure_getenv strndup strptime utimensat vsyslog])
 AC_CONFIG_HEADERS([config.h])
 
 AM_CFLAGS="\


### PR DESCRIPTION
`secure_getenv` is not available on non-GNU systems (such as macOS)