### PR TITLE
logrotate.service: harden with ProtectHostname and RestrictSUIDSGID

### DIFF
--- a/examples/logrotate.service
+++ b/examples/logrotate.service
@@ -18,12 +18,14 @@ IOSchedulingPriority=7
 #  no ProtectHome for userdir logs
 #  no PrivateNetwork for mail deliviery
 #  no NoNewPrivileges for third party rotate scripts
+#  no RestrictSUIDSGID for creating setgid directories
 LockPersonality=true
 MemoryDenyWriteExecute=true
 PrivateDevices=true
 PrivateTmp=true
 ProtectClock=true
 ProtectControlGroups=true
+ProtectHostname=true
 ProtectKernelLogs=true
 ProtectKernelModules=true
 ProtectKernelTunables=true


### PR DESCRIPTION
Prohibit changing the system hostname/domain and creating SUID/SGID files