### PR TITLE
test-70: fix minage test in reprotest environment

### DIFF
--- a/test/test-0070.sh
+++ b/test/test-0070.sh
@@ -8,15 +8,10 @@ cleanup 70
 # No rotation should occur because file is too young
 preptest test.log 70 2
 
-# Put in place a state file that will force a rotation
-cat > state <<EOF
-logrotate state -- version 2
-"$PWD/test.log" $(($(date "+%Y") - 10))-1-1
-EOF
-
 $RLR test-config.70
 
 checkoutput <<EOF
 test.log 0 zero
 test.log.1 0 first
+test.log.2 0 second
 EOF


### PR DESCRIPTION
The minage condition is based on the mtime of the log file,
not on the rotation date from the state file.
During reproducibility test, which changes the system time, this test
may fail due to the file actually being to old.
This test 70 should assure that we do not rotate, actual rotation is
tested in test 71.