### PR TITLE
tests: always run logrotate in verbose mode

### DIFF
--- a/test/test-0069.sh
+++ b/test/test-0069.sh
@@ -12,7 +12,7 @@ mkdir adir
 mkdir bdir
 cp test.log adir
 cp test.log bdir
-$RLR test-config.69 --force -v
+$RLR test-config.69 --force
 
 checkoutput <<EOF
 adir/test.log 0

--- a/test/test-0074.sh
+++ b/test/test-0074.sh
@@ -9,7 +9,7 @@ cleanup 74
 # https://github.com/logrotate/logrotate/issues/144
 preptest test.log 74 1
 
-$RLR test-config.74 --verbose
+$RLR test-config.74
 
 checkoutput <<EOF
 test.log 0

--- a/test/test-0075.sh
+++ b/test/test-0075.sh
@@ -9,7 +9,7 @@ cleanup 75
 # https://github.com/logrotate/logrotate/issues/151
 preptest test.log 75 2 1
 
-$RLR test-config.75 --verbose
+$RLR test-config.75
 
 checkoutput <<EOF
 test.log 0

--- a/test/test-0076.sh
+++ b/test/test-0076.sh
@@ -9,7 +9,7 @@ cleanup 76
 # https://github.com/logrotate/logrotate/issues/154
 preptest test.log 76 2 2
 
-$RLR test-config.76 --verbose <&- >&-
+$RLR test-config.76 <&- >&-
 
 checkoutput <<EOF
 test.log 0

--- a/test/test-0077.sh
+++ b/test/test-0077.sh
@@ -14,7 +14,7 @@ rotate 1
 EOF
 chmod go-w includedir/test-0077.conf
 
-$RLR test-config.77 --force --verbose
+$RLR test-config.77 --force
 
 rm -rf includedir
 

--- a/test/test-0079.sh
+++ b/test/test-0079.sh
@@ -6,7 +6,7 @@ cleanup 79
 
 # ------------------------------- Test 79 ------------------------------------
 preptest test.log 79 1
-$RLR test-config.79 -v --force >verbose.log
+$RLR test-config.79 --force >verbose.log
 if [ $? != 0 ]; then
 	echo "Logrotate exited with a non-zero exit code, but it should not have"
 	exit 3

--- a/test/test-0082.sh
+++ b/test/test-0082.sh
@@ -8,7 +8,7 @@ cleanup 82
 preptest test.log 82 0
 
 for i in $(seq 32); do
-    $RLR test-config.82 -v --force
+    $RLR test-config.82 --force
 done
 
 test "$(ls test.log.* | wc -l)" -eq 32

--- a/test/test-0083.sh
+++ b/test/test-0083.sh
@@ -7,7 +7,7 @@ cleanup 83
 # ------------------------------- Test 83 ------------------------------------
 preptest test.log 83 1
 
-if $RLR test-config.83 -v --force; then
+if $RLR test-config.83 --force; then
     exit 1
 else
     exit 0

--- a/test/test-0084.sh
+++ b/test/test-0084.sh
@@ -11,4 +11,4 @@ mkdir -p log/dir
 ln -s XXX log/sym
 touch log/dir/file
 
-$RLR test-config.84 -v --force
+$RLR test-config.84 --force

--- a/test/test-0087.sh
+++ b/test/test-0087.sh
@@ -9,11 +9,11 @@ preptest test.log 87 1
 
 touch state
 
-$RLR test-config.87 -v -f &
+$RLR test-config.87 -f &
 
 sleep 2
 
-$RLR test-config.87 -v
+$RLR test-config.87
 ret=$?
 
 if [ $ret -ne 3 ]; then

--- a/test/test-common.sh
+++ b/test/test-common.sh
@@ -1,6 +1,6 @@
 # common variables and functions for legacy tests
 LOGROTATE="$(readlink -f $LOGROTATE)"
-RLR="$LOGROTATE -m ./mailer -s state"
+RLR="$LOGROTATE -v -m ./mailer -s state"
 
 TESTDIR="$(basename "$0" .sh)"
 mkdir -p "$TESTDIR"


### PR DESCRIPTION
In case of failures the output is more detailed;
on success the output is discarded.