### PR TITLE
test-70: set log modification time to current date

### DIFF
--- a/test/test-0070.sh
+++ b/test/test-0070.sh
@@ -8,7 +8,26 @@ cleanup 70
 # No rotation should occur because file is too young
 preptest test.log 70 2
 
-# Put in place a state file that will force a rotation
+# Set log modification time to current date.
+# In reprotest (with faketime(1)) environments the logs might not be created
+# with the faked system time.
+touch -t $(date +%Y%m%d%H%M) test.log
+
+checkoutput <<EOF
+test.log 0 zero
+test.log.1 0 first
+test.log.2 0 second
+EOF
+
+$RLR test-config.70
+
+checkoutput <<EOF
+test.log 0 zero
+test.log.1 0 first
+test.log.2 0 second
+EOF
+
+# Put in place a state with an old rotation date
 cat > state <<EOF
 logrotate state -- version 2
 "$PWD/test.log" $(($(date "+%Y") - 10))-1-1
@@ -19,4 +38,5 @@ $RLR test-config.70
 checkoutput <<EOF
 test.log 0 zero
 test.log.1 0 first
+test.log.2 0 second
 EOF


### PR DESCRIPTION
In reprotest (with faketime(1)) environments the logs might not be
created with the faked system time so a rotation could happen if the
system time gets forwarded (so the minage condition becomes true).