### PR TITLE
Ensure the type for configuration flags is big enough

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,8 @@ AC_STRUCT_ST_BLOCKS
 
 AC_CANONICAL_HOST
 
+AC_TYPE_UINT32_T
+
 dnl Use 64-bit file offsets on 32-bit systems (defines C macros if necessary)
 AC_SYS_LARGEFILE
 

--- a/logrotate.c
+++ b/logrotate.c
@@ -1187,7 +1187,7 @@ static int sparse_copy(int src_fd, int dest_fd, const struct stat *sb,
 }
 
 static int copyTruncate(const char *currLog, const char *saveLog, const struct stat *sb,
-                        int flags, int skip_copy)
+                        uint32_t flags, int skip_copy)
 {
     int rc = 1;
     int fdcurr = -1, fdsave = -1;

--- a/logrotate.h
+++ b/logrotate.h
@@ -1,6 +1,7 @@
 #ifndef H_LOGROTATE
 #define H_LOGROTATE
 
+#include <stdint.h>
 #include <sys/types.h>
 #include "queue.h"
 #include <glob.h>
@@ -10,22 +11,22 @@
 #   include <libgen.h>
 #endif
 
-#define LOG_FLAG_COMPRESS       (1 << 0)
-#define LOG_FLAG_CREATE         (1 << 1)
-#define LOG_FLAG_IFEMPTY        (1 << 2)
-#define LOG_FLAG_DELAYCOMPRESS  (1 << 3)
-#define LOG_FLAG_COPYTRUNCATE   (1 << 4)
-#define LOG_FLAG_MISSINGOK      (1 << 5)
-#define LOG_FLAG_MAILFIRST      (1 << 6)
-#define LOG_FLAG_SHAREDSCRIPTS  (1 << 7)
-#define LOG_FLAG_COPY           (1 << 8)
-#define LOG_FLAG_DATEEXT        (1 << 9)
-#define LOG_FLAG_SHRED          (1 << 10)
-#define LOG_FLAG_SU             (1 << 11)
-#define LOG_FLAG_DATEYESTERDAY  (1 << 12)
-#define LOG_FLAG_OLDDIRCREATE   (1 << 13)
-#define LOG_FLAG_TMPFILENAME    (1 << 14)
-#define LOG_FLAG_DATEHOURAGO    (1 << 15)
+#define LOG_FLAG_COMPRESS       (1U << 0)
+#define LOG_FLAG_CREATE         (1U << 1)
+#define LOG_FLAG_IFEMPTY        (1U << 2)
+#define LOG_FLAG_DELAYCOMPRESS  (1U << 3)
+#define LOG_FLAG_COPYTRUNCATE   (1U << 4)
+#define LOG_FLAG_MISSINGOK      (1U << 5)
+#define LOG_FLAG_MAILFIRST      (1U << 6)
+#define LOG_FLAG_SHAREDSCRIPTS  (1U << 7)
+#define LOG_FLAG_COPY           (1U << 8)
+#define LOG_FLAG_DATEEXT        (1U << 9)
+#define LOG_FLAG_SHRED          (1U << 10)
+#define LOG_FLAG_SU             (1U << 11)
+#define LOG_FLAG_DATEYESTERDAY  (1U << 12)
+#define LOG_FLAG_OLDDIRCREATE   (1U << 13)
+#define LOG_FLAG_TMPFILENAME    (1U << 14)
+#define LOG_FLAG_DATEHOURAGO    (1U << 15)
 
 #define NO_MODE ((mode_t) -1)
 #define NO_UID  ((uid_t) -1)
@@ -70,7 +71,7 @@ struct logInfo {
     char *uncompress_prog;
     char *compress_ext;
     char *dateformat;               /* specify format for strftime (for dateext) */
-    int flags;
+    uint32_t flags;
     int shred_cycles;               /* if !=0, pass -n shred_cycles to GNU shred */
     mode_t createMode;              /* if any/all of these are -1, we use the */
     uid_t createUid;                /* attributes from the log file just rotated */


### PR DESCRIPTION
On 32-bit platform int might be only 16 bit wide.
With #361 we would exceed this range.