### PR TITLE
Lambda user

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -774,6 +774,8 @@ static int compressLogFile(const char *name, const struct logInfo *log, const st
     int error_printed = 0;
     char *prevCtx;
     pid_t pid;
+    int in_flags;
+    const char *in_how;
 
     message(MESS_DEBUG, "compressing log with: %s\n", log->compress_prog);
     if (debug)
@@ -789,10 +791,18 @@ static int compressLogFile(const char *name, const struct logInfo *log, const st
     compressedName = alloca(strlen(name) + strlen(log->compress_ext) + 2);
     sprintf(compressedName, "%s%s", name, log->compress_ext);
 
-    /* We do not need write permission on that file to compress it */
-    if ((inFile = open(name, O_RDONLY | O_NOFOLLOW)) < 0) {
-        message(MESS_ERROR, "unable to open %s for compression: %s\n",
-            name, strerror(errno));
+    in_flags = O_NOFOLLOW;
+    if (log->flags & LOG_FLAG_SHRED) {
+        /* need write access for shredding */
+        in_flags |= O_RDWR;
+        in_how = "read-write";
+    } else {
+        in_flags |= O_RDONLY;
+        in_how = "read-only";
+    }
+    if ((inFile = open(name, in_flags)) < 0) {
+        message(MESS_ERROR, "unable to open %s (%s) for compression: %s\n",
+            name, in_how, strerror(errno));
         return 1;
     }
 

--- a/logrotate.c
+++ b/logrotate.c
@@ -785,8 +785,10 @@ static int compressLogFile(const char *name, const struct logInfo *log, const st
     compressedName = alloca(strlen(name) + strlen(log->compress_ext) + 2);
     sprintf(compressedName, "%s%s", name, log->compress_ext);
 
-    if ((inFile = open(name, O_RDWR | O_NOFOLLOW)) < 0) {
-        message(MESS_ERROR, "unable to open %s for compression: %s\n", name, strerror(errno));
+    /* We do not need write permission on that file to compress it */
+    if ((inFile = open(name, O_RDONLY | O_NOFOLLOW)) < 0) {
+        message(MESS_ERROR, "unable to open %s for compression: %s\n",
+            name, strerror(errno));
         return 1;
     }
 

--- a/logrotate.c
+++ b/logrotate.c
@@ -584,7 +584,7 @@ static int createOutputFile(const char *fileName, int flags, const struct stat *
 
     /* Only attempt to set user/group if running as root */
     if (
-        0 == geteuid() &&
+        ROOT_UID == geteuid() &&
         (sb_create.st_uid != sb->st_uid || sb_create.st_gid != sb->st_gid) &&
         fchown(fd, sb->st_uid, sb->st_gid)
     ) {

--- a/logrotate.c
+++ b/logrotate.c
@@ -582,8 +582,12 @@ static int createOutputFile(const char *fileName, int flags, const struct stat *
         return -1;
     }
 
-    if ((sb_create.st_uid != sb->st_uid || sb_create.st_gid != sb->st_gid) &&
-            fchown(fd, sb->st_uid, sb->st_gid)) {
+    /* Only attempt to set user/group if running as root */
+    if (
+        0 == geteuid() &&
+        (sb_create.st_uid != sb->st_uid || sb_create.st_gid != sb->st_gid) &&
+        fchown(fd, sb->st_uid, sb->st_gid)
+    ) {
         message(MESS_ERROR, "error setting owner of %s to uid %u and gid %u: %s\n",
                 fileName, (unsigned) sb->st_uid, (unsigned) sb->st_gid, strerror(errno));
         close(fd);


### PR DESCRIPTION
Small changes required to allow a normal user to run logrotate on files that do not belong to user.

This is useful when a container writes logs to a mapped directory, belonging to the user, but whose files have "foreign ids" (those of the container environment).  The ability to rotate the logs and have the logs compressed is important but requires that logs be opened read-only when compressing them, and that no attempt be made to "chown" them to the same uid/gid as the original log file.