### PR TITLE
Fix a typo in the example logrotate.conf

### DIFF
--- a/examples/logrotate.conf
+++ b/examples/logrotate.conf
@@ -20,4 +20,4 @@ dateext
 # packages drop log rotation information into this directory
 include /etc/logrotate.d
 
-# system-specific logs may be also be configured here.
+# system-specific logs may also be configured here.


### PR DESCRIPTION
Hi, please find a small fix for a typo in `logrotate.conf`.