### PR TITLE
tests: use md5 instead of gmd5sum on FreeBSD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -153,7 +153,7 @@ install:
     fi
   - |
     if [[ "${TRAVIS_OS_NAME}" = "freebsd" ]]; then
-      sudo pkg install --yes coreutils gzip popt
+      sudo pkg install --yes gzip popt
     fi
 
 script:

--- a/test/test-common.sh
+++ b/test/test-common.sh
@@ -15,10 +15,10 @@ fi
 
 if command -v md5sum > /dev/null 2>&1; then
   MD5SUM=md5sum
-elif command -v gmd5sum > /dev/null 2>&1; then
-  MD5SUM=gmd5sum
+elif command -v md5 > /dev/null 2>&1; then
+  MD5SUM=md5
 else
-  echo "no md5sum command found"
+  echo "no md5sum/md5 command found"
   exit 1
 fi
 


### PR DESCRIPTION
gmd5sum from the package coreutils is currently unmaintained and fails
to work on travis.

Use the BSD tool md5(1).