### PR TITLE
fix resource leaks reported by Coverity

### DIFF
--- a/config.c
+++ b/config.c
@@ -2113,12 +2113,14 @@ next_state: ;
 
     munmap(buf, length);
     close(fd);
+    free(globerr_msg);
     return logerror;
 error:
     /* free is a NULL-safe operation */
     free(key);
     munmap(buf, length);
     close(fd);
+    free(globerr_msg);
     return 1;
 }
 

--- a/logrotate.c
+++ b/logrotate.c
@@ -1919,6 +1919,7 @@ static int prerotateSingleLog(const struct logInfo *log, unsigned logNum,
             rotNames->disposeName = strdup(oldName);
             if (rotNames->disposeName == NULL) {
                 message_OOM();
+                free(oldName);
                 return 1;
             }
         }
@@ -1927,6 +1928,7 @@ static int prerotateSingleLog(const struct logInfo *log, unsigned logNum,
                 rotNames->baseName, logStart, fileext,
                 (log->flags & LOG_FLAG_DELAYCOMPRESS) ? "" : compext) < 0) {
             message_OOM();
+            free(oldName);
             rotNames->firstRotated = NULL;
             return 1;
         }


### PR DESCRIPTION
```
Error: RESOURCE_LEAK (CWE-772):
logrotate-3.18.0.18_7a4d/config.c:1798: alloc_arg: "asprintf" allocates memory that is stored into "globerr_msg". [Note: The source code implementation of the function has been overridden by a builtin model.]
logrotate-3.18.0.18_7a4d/config.c:2116: leaked_storage: Variable "globerr_msg" going out of scope leaks the storage it points to.
# 2114|       munmap(buf, length);
# 2115|       close(fd);
# 2116|->     return logerror;
# 2117|   error:
# 2118|       /* free is a NULL-safe operation */

Error: RESOURCE_LEAK (CWE-772):
logrotate-3.18.0.18_7a4d/config.c:1798: alloc_arg: "asprintf" allocates memory that is stored into "globerr_msg". [Note: The source code implementation of the function has been overridden by a builtin model.]
logrotate-3.18.0.18_7a4d/config.c:2122: leaked_storage: Variable "globerr_msg" going out of scope leaks the storage it points to.
# 2120|       munmap(buf, length);
# 2121|       close(fd);
# 2122|->     return 1;
# 2123|   }
# 2124|   

Error: RESOURCE_LEAK (CWE-772):
logrotate-3.18.0.18_7a4d/logrotate.c:1911: alloc_arg: "asprintf" allocates memory that is stored into "oldName". [Note: The source code implementation of the function has been overridden by a builtin model.]
logrotate-3.18.0.18_7a4d/logrotate.c:1919: noescape: Resource "oldName" is not freed or pointed-to in "strdup".
logrotate-3.18.0.18_7a4d/logrotate.c:1922: leaked_storage: Variable "oldName" going out of scope leaks the storage it points to.
# 1920|               if (rotNames->disposeName == NULL) {
# 1921|                   message_OOM();
# 1922|->                 return 1;
# 1923|               }
# 1924|           }

Error: RESOURCE_LEAK (CWE-772):
logrotate-3.18.0.18_7a4d/logrotate.c:1911: alloc_arg: "asprintf" allocates memory that is stored into "oldName". [Note: The source code implementation of the function has been overridden by a builtin model.]
logrotate-3.18.0.18_7a4d/logrotate.c:1919: noescape: Resource "oldName" is not freed or pointed-to in "strdup".
logrotate-3.18.0.18_7a4d/logrotate.c:1931: leaked_storage: Variable "oldName" going out of scope leaks the storage it points to.
# 1929|               message_OOM();
# 1930|               rotNames->firstRotated = NULL;
# 1931|->             return 1;
# 1932|           }
# 1933|   
```