### PR TITLE
Use correct length for madvise(3)

### DIFF
--- a/config.c
+++ b/config.c
@@ -1066,11 +1066,9 @@ static int readConfigFile(const char *configFile, struct logInfo *defConfig)
 
 #ifdef HAVE_MADVISE
 #ifdef MADV_DONTFORK
-    r = madvise(buf, length + 2,
-                MADV_SEQUENTIAL | MADV_WILLNEED | MADV_DONTFORK);
+    r = madvise(buf, length, MADV_SEQUENTIAL | MADV_WILLNEED | MADV_DONTFORK);
 #else /* MADV_DONTFORK */
-    r = madvise(buf, length + 2,
-                MADV_SEQUENTIAL | MADV_WILLNEED);
+    r = madvise(buf, length, MADV_SEQUENTIAL | MADV_WILLNEED);
 #endif /* MADV_DONTFORK */
     if (r < 0) {
         message(MESS_DEBUG, "Failed to advise use of memory: %s\n",


### PR DESCRIPTION
Originally in cb19e6c2 ("mmap config files") an area of `length + 2` was
mapped, cause "\n\0" was appended for parsing.

In 1d61ce17
("Rewriten config parser to fix parsing config files with 4096*n size")
the mapping was reduced to just `length` due to parser rework, but the
size in the madvise(3) was not adjusted.

Align the advice size to the mapped size.