### PR TITLE
add documentation for --state /dev/null special case

### DIFF
--- a/logrotate.8.in
+++ b/logrotate.8.in
@@ -75,6 +75,8 @@ if \fBlogrotate\fR is being run as a different user for various sets of
 log files.  To prevent parallel execution \fBlogrotate\fR by default
 acquires a lock on the state file, if it cannot be acquired \fBlogrotate\fR
 will exit with value 3.  The default state file is \fI@STATE_FILE_PATH@\fR.
+If \fI/dev/null\fR is given as the state file, then \fBlogrotate\fR will
+not try writing the state file.
 
 .TP
 \fB\-\-skip-state-lock\fR


### PR DESCRIPTION
This is documentation for the suggested implementation of #395 aka `--state /dev/null` will not write any state file.