### PR TITLE
RFC: forbid rotating hardlinks as root

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -547,7 +547,7 @@ static int createOutputFile(const char *fileName, int flags, const struct stat *
         size_t fileName_size, buf_size;
         char *backupName, *ptr;
 
-        fd = open(fileName, (flags | O_EXCL | O_NOFOLLOW),
+        fd = open(fileName, (flags | O_CREAT | O_EXCL | O_NOFOLLOW),
                 (S_IRUSR | S_IWUSR) & sb->st_mode);
 
         if ((fd >= 0) || (errno != EEXIST))
@@ -857,7 +857,7 @@ static int compressLogFile(const char *name, const struct logInfo *log, const st
 #endif
 
     outFile =
-        createOutputFile(compressedName, O_RDWR | O_CREAT, sb, prev_acl, 0);
+        createOutputFile(compressedName, O_RDWR, sb, prev_acl, 0);
     restoreSecCtx(&prevCtx);
 #ifdef WITH_ACL
     if (prev_acl) {
@@ -1237,7 +1237,7 @@ static int copyTruncate(const char *currLog, const char *saveLog, const struct s
                 }
             }
 #endif /* WITH_ACL */
-            fdsave = createOutputFile(saveLog, O_WRONLY | O_CREAT, sb, prev_acl, 0);
+            fdsave = createOutputFile(saveLog, O_WRONLY, sb, prev_acl, 0);
             restoreSecCtx(&prevCtx);
 #ifdef WITH_ACL
             if (prev_acl) {
@@ -2173,7 +2173,7 @@ static int rotateSingleLog(const struct logInfo *log, unsigned logNum,
 
             if (!debug) {
                 if (!hasErrors) {
-                    int fd = createOutputFile(log->files[logNum], O_CREAT | O_RDWR,
+                    int fd = createOutputFile(log->files[logNum], O_RDWR,
                             &sb, prev_acl, have_create_mode);
 #ifdef WITH_ACL
                     if (prev_acl) {
@@ -2624,7 +2624,7 @@ static int writeState(const char *stateFilename)
 
     close(fdcurr);
 
-    fdsave = createOutputFile(tmpFilename, O_RDWR | O_CREAT | O_TRUNC, &sb, prev_acl, 0);
+    fdsave = createOutputFile(tmpFilename, O_RDWR, &sb, prev_acl, 0);
 #ifdef WITH_ACL
     if (prev_acl) {
         acl_free(prev_acl);

--- a/logrotate.c
+++ b/logrotate.c
@@ -203,7 +203,7 @@ static int switch_user_permanently(const struct logInfo *log) {
         return 1;
     }
 
-    if (user != ROOT_UID && setuid(ROOT_UID) != -1) {
+    if (user != ROOT_UID && (setuid(ROOT_UID) != -1 || seteuid(ROOT_UID) != -1)) {
         message(MESS_ERROR, "failed to switch user permanently, able to switch back (pid %d)\n",
                 getpid());
         return 1;

--- a/logrotate.c
+++ b/logrotate.c
@@ -209,6 +209,12 @@ static int switch_user_permanently(const struct logInfo *log) {
         return 1;
     }
 
+    if (chdir("/") != 0) {
+        message(MESS_ERROR, "failed to change current directory to root path: %s\n",
+                strerror(errno));
+        return -1;
+    }
+
     return 0;
 }
 

--- a/logrotate.c
+++ b/logrotate.c
@@ -422,7 +422,13 @@ static int setSecCtxByName(const char *src, char **pPrevCtx)
 {
     int hasErrors = 0;
 #ifdef WITH_SELINUX
-    int fd = open_logfile(src, O_RDONLY);
+    int fd;
+
+    if (!selinux_enabled)
+        /* pretend success */
+        return 0;
+
+    fd = open_logfile(src, O_RDONLY);
     if (fd < 0) {
         message(MESS_ERROR, "error opening %s: %s\n", src, strerror(errno));
         return 1;


### PR DESCRIPTION
Related: #237 

To avoid any kind of attack scenarios with malicious hard-links to privileged file (like */etc/shadow*) do not rotate hard-links as root (we already do not rotate symbolic-links).