### PR TITLE
Do not open symbolic link log files by accident

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -225,6 +225,28 @@ static int switch_user_back_permanently(void) {
     return ret;
 }
 
+static int open_logfile(const char *path, int write_access) {
+    int fd;
+    struct stat sb;
+
+    fd = open(path, O_NOFOLLOW | (write_access ? O_RDWR : O_RDONLY));
+    if (fd < 0)
+        return fd;
+
+    if (fstat(fd, &sb) != 0) {
+        close(fd);
+        return -1;
+    }
+
+    if (! S_ISREG(sb.st_mode)) {
+        close(fd);
+        errno = ENOTSUP;
+        return -1;
+    }
+
+    return fd;
+}
+
 static void unescape(char *arg)
 {
     char *p = arg;
@@ -379,7 +401,7 @@ static int setSecCtxByName(const char *src, char **pPrevCtx)
         /* pretend success */
         return 0;
 
-    fd = open(src, O_RDONLY | O_NOFOLLOW);
+    fd = open_logfile(src, 0);
     if (fd < 0) {
         message(MESS_ERROR, "error opening %s: %s\n", src, strerror(errno));
         return 1;
@@ -727,7 +749,7 @@ static int removeLogFile(const char *name, const struct logInfo *log)
     message(MESS_DEBUG, "removing old log %s\n", name);
 
     if (log->flags & LOG_FLAG_SHRED) {
-        fd = open(name, O_RDWR | O_NOFOLLOW);
+        fd = open_logfile(name, 1);
         if (fd < 0) {
             message(MESS_ERROR, "error opening %s: %s\n",
                     name, strerror(errno));
@@ -780,8 +802,6 @@ static int compressLogFile(const char *name, const struct logInfo *log, const st
     int error_printed = 0;
     char *prevCtx;
     pid_t pid;
-    int in_flags;
-    const char *in_how;
 
     message(MESS_DEBUG, "compressing log with: %s\n", log->compress_prog);
     if (debug)
@@ -797,18 +817,9 @@ static int compressLogFile(const char *name, const struct logInfo *log, const st
     compressedName = alloca(strlen(name) + strlen(log->compress_ext) + 2);
     sprintf(compressedName, "%s%s", name, log->compress_ext);
 
-    in_flags = O_NOFOLLOW;
-    if (log->flags & LOG_FLAG_SHRED) {
-        /* need write access for shredding */
-        in_flags |= O_RDWR;
-        in_how = "read-write";
-    } else {
-        in_flags |= O_RDONLY;
-        in_how = "read-only";
-    }
-    if ((inFile = open(name, in_flags)) < 0) {
+    if ((inFile = open_logfile(name, log->flags & LOG_FLAG_SHRED)) < 0) {
         message(MESS_ERROR, "unable to open %s (%s) for compression: %s\n",
-            name, in_how, strerror(errno));
+            name, (log->flags & LOG_FLAG_SHRED) ? "read-write" : "read-only", strerror(errno));
         return 1;
     }
 
@@ -934,7 +945,7 @@ static int mailLog(const struct logInfo *log, const char *logFile, const char *m
     char * const mailArgv[] = { (char *) mailComm, (char *) "-s", (char *) subject, (char *) address, NULL };
     int rc = 0;
 
-    if ((mailInput = open(logFile, O_RDONLY | O_NOFOLLOW)) < 0) {
+    if ((mailInput = open_logfile(logFile, 0)) < 0) {
         message(MESS_ERROR, "failed to open %s for mailing: %s\n", logFile,
                 strerror(errno));
         return 1;
@@ -1188,7 +1199,7 @@ static int copyTruncate(const char *currLog, const char *saveLog, const struct s
         /* read access is sufficient for 'copy' but not for 'copytruncate' */
         const int read_only = (flags & LOG_FLAG_COPY)
             && !(flags & LOG_FLAG_COPYTRUNCATE);
-        if ((fdcurr = open(currLog, ((read_only) ? O_RDONLY : O_RDWR) | O_NOFOLLOW)) < 0) {
+        if ((fdcurr = open_logfile(currLog, !read_only)) < 0) {
             message(MESS_ERROR, "error opening %s: %s\n", currLog,
                     strerror(errno));
             goto fail;


### PR DESCRIPTION
We do check a priori if a log file is a symbolic link and skip such
files.  Avoid race conditions where a regular file gets replaced by a
symbolic link after that check, causing logrotate to rotate the content
of the link target.