### PR TITLE
Add early skip in setSecCtxByName

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -373,7 +373,13 @@ static int setSecCtxByName(const char *src, char **pPrevCtx)
 {
     int hasErrors = 0;
 #ifdef WITH_SELINUX
-    int fd = open(src, O_RDONLY | O_NOFOLLOW);
+    int fd;
+
+    if (!selinux_enabled)
+        /* pretend success */
+        return 0;
+
+    fd = open(src, O_RDONLY | O_NOFOLLOW);
     if (fd < 0) {
         message(MESS_ERROR, "error opening %s: %s\n", src, strerror(errno));
         return 1;


### PR DESCRIPTION
If build with SELinux support but SELinux is disabled do not
unnecessarily open a file in `setSecCtxByName()`, as `setSecCtx()` will
be a no-op.