### PR TITLE
Require qsort and strptime

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -165,7 +165,7 @@ AC_SUBST(COMPRESS_EXT)
 AC_DEFINE_UNQUOTED([ROOT_UID], [0], [Root user-id.])
 AC_SUBST(ROOT_UID)
 
-AC_CHECK_FUNCS([asprintf madvise qsort secure_getenv strndup strptime utimensat vsyslog])
+AC_CHECK_FUNCS([asprintf madvise secure_getenv strndup utimensat vsyslog])
 AC_CONFIG_HEADERS([config.h])
 
 AM_CFLAGS="\

--- a/logrotate.c
+++ b/logrotate.c
@@ -108,8 +108,6 @@ static int globerr(const char *pathname, int theerr)
     return 1;
 }
 
-#if defined(HAVE_STRPTIME) && defined(HAVE_QSORT)
-
 /* We could switch to qsort_r to get rid of this global variable,
  * but qsort_r is not portable enough (Linux vs. *BSD vs ...)... */
 static struct compData _compData;
@@ -142,11 +140,6 @@ static void sortGlobResult(glob_t *result, size_t prefix_len, const char *dforma
     _compData.dformat = dformat;
     qsort(result->gl_pathv, result->gl_pathc, sizeof(char *), compGlobResult);
 }
-#else
-static void sortGlobResult(glob_t *result, size_t prefix_len, const char *dformat) {
-    /* TODO */
-}
-#endif
 
 int switch_user(uid_t user, gid_t group) {
     save_egid = getegid();


### PR DESCRIPTION
qsort(3) is specified in C89 and POSIX.1-2001 and strptime(3) is specified in POSIX.1-2001.

This allows to drop the unimplemented fallback code.