### PR TITLE
Do not rotate hard links by default

### DIFF
--- a/config.c
+++ b/config.c
@@ -1126,6 +1126,10 @@ static int readConfigFile(const char *configFile, struct logInfo *defConfig)
                         newlog->flags |= LOG_FLAG_SHRED;
                     } else if (!strcmp(key, "noshred")) {
                         newlog->flags &= ~LOG_FLAG_SHRED;
+                    } else if (!strcmp(key, "allowhardlink")) {
+                        newlog->flags |= LOG_FLAG_ALLOWHARDLINK;
+                    } else if (!strcmp(key, "noallowhardlink")) {
+                        newlog->flags &= ~LOG_FLAG_ALLOWHARDLINK;
                     } else if (!strcmp(key, "sharedscripts")) {
                         newlog->flags |= LOG_FLAG_SHAREDSCRIPTS;
                     } else if (!strcmp(key, "nosharedscripts")) {

--- a/logrotate.8.in
+++ b/logrotate.8.in
@@ -467,6 +467,16 @@ Do not use \fBshred\fR when deleting old log files.  See also \fBshred\fR.
 Asks GNU \fBshred\fR(1) to overwrite log files \fBcount\fR times before
 deletion.  Without this option, \fBshred\fR's default will be used.
 
+.TP
+\fBallowhardlink\fR
+Rotate files with multiple hard links; this is off by default.  The target file
+might get emptied, e.g. with \fBshred\fR or \fBcopytruncate\fR.  Use with
+caution, especially when the log files are rotated as root.
+
+.TP
+\fBnoallowhardlink\fR
+Do not rotate files with multiple hard links.  See also \fBallowhardlink\fR.
+
 .SS Compression
 
 .TP

--- a/logrotate.h
+++ b/logrotate.h
@@ -27,6 +27,7 @@
 #define LOG_FLAG_OLDDIRCREATE   (1U << 13)
 #define LOG_FLAG_TMPFILENAME    (1U << 14)
 #define LOG_FLAG_DATEHOURAGO    (1U << 15)
+#define LOG_FLAG_ALLOWHARDLINK  (1U << 16)
 
 #define NO_MODE ((mode_t) -1)
 #define NO_UID  ((uid_t) -1)

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -88,6 +88,8 @@ TEST_CASES = \
 	test-0087.sh \
 	test-0088.sh \
 	test-0089.sh \
+	test-0090.sh \
+	test-0091.sh \
 	test-0100.sh \
 	test-0101.sh
 

--- a/test/test-0090.sh
+++ b/test/test-0090.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+. ./test-common.sh
+
+# we don't want any stuff left from previous runs
+cleanup 90
+rm -Rf real*.log*
+
+# ------------------------------- Test 90 ------------------------------------
+# do not rotate file with multiple hard links by default
+preptest real.log 90 0
+ln real.log test.log
+
+$RLR -f test-config.90 || exit 23
+
+checkoutput <<EOF
+test.log 0 zero
+EOF
+
+if [ -e test.log.1 ]; then
+    echo "test.log.1 exists!"
+    exit 3
+fi
+
+if [ -e real.log.1 ]; then
+    echo "real.log.1 exists!"
+    exit 3
+fi

--- a/test/test-0091.sh
+++ b/test/test-0091.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+. ./test-common.sh
+
+# we don't want any stuff left from previous runs
+cleanup 91
+rm -Rf real*.log*
+
+# ------------------------------- Test 91 ------------------------------------
+# rotate file with multiple hard links when enabled
+preptest real.log 91 0
+ln real.log test.log
+
+$RLR -f test-config.91 || exit 23
+
+checkoutput <<EOF
+test.log 0
+test.log.1 0 zero
+real.log 0
+EOF

--- a/test/test-config.90.in
+++ b/test/test-config.90.in
@@ -1,0 +1,3 @@
+&DIR&/test.log {
+    rotate 1
+}

--- a/test/test-config.91.in
+++ b/test/test-config.91.in
@@ -1,0 +1,5 @@
+&DIR&/test.log {
+    rotate 1
+    allowhardlink
+    copytruncate
+}


### PR DESCRIPTION
Hard links are quite unusual to be a target of log rotation.
They can be subject of attacks since users might create hard links to
privileged files, like /etc/shadow, leading programs running as root to
modify the original privileged file through this link.

Add configuration directives `hardlink` and `nohardlink` to control
whether to rotate had links, whereby `nohardlink` is the default.

logrotate already does not rotate symbolic links.

Alternative to #397.