### PR TITLE
Remove invalid configuration on error

### DIFF
--- a/config.c
+++ b/config.c
@@ -2137,6 +2137,8 @@ next_state: ;
     free(globerr_msg);
     return logerror;
 error:
+    if (newlog != defConfig)
+        freeTailLogs(1);
     /* free is a NULL-safe operation */
     free(key);
     munmap(buf, length);

--- a/logrotate.c
+++ b/logrotate.c
@@ -2991,9 +2991,9 @@ int main(int argc, const char **argv)
     int arg;
     const char **files;
     poptContext optCon;
-    struct logInfo *log;
+    const struct logInfo *log;
 
-    struct poptOption options[] = {
+    const struct poptOption options[] = {
         {"debug", 'd', 0, NULL, 'd',
             "Don't do anything, just test and print debug messages", NULL},
         {"force", 'f', 0, &force, 0, "Force file rotation", NULL},


### PR DESCRIPTION
After failing while parsing an invalid configuration file, like:
```
/some/path
```

remove the erroneous configuration structure from the internal list.

Else one might see:

    reading config file config.tmp
    error: config.tmp:1 missing '{' after log files definition
    Reading state from file: state.tmp
    error: error opening state file state.tmp: No such file or directory
    Allocating hash table for state file, size 64 entries

    Handling 1 logs

    rotating pattern: (null) forced from command line (no old logs will be kept)
    empty log files are rotated, old logs are removed
    No logs found. Rotation not needed.