### PR TITLE
Add automake options -Wall and std-options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -171,6 +171,8 @@ script:
   - make -j9 check || ( cat test/test-suite.log; exit 1; )
   # scan for Sanitizer output
   - grep -riE 'sanitizer|runtime error' test/*.log; test $? -eq 1
+  - sudo make install
+  - make installcheck
   - make -j9 distcheck DISTCHECK_CONFIGURE_FLAGS="--enable-werror --disable-silent-rules $CONFIGURE_OPTS"
   # nodeps because rpm build deps cannot be installed on debian system
   - |

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ AC_INIT([logrotate],m4_esyscmd([build-aux/git-version-gen --prefix '' .tarball-v
 
 dnl foreign: Do not require AUTHORS, ChangeLog, NEWS, and README to exist
 dnl dist-xz: Produce tar.xz version of the release archive
-AM_INIT_AUTOMAKE(foreign dist-xz)
+AM_INIT_AUTOMAKE([-Wall foreign dist-xz std-options])
 
 # --enable-silent-rules
 m4_ifdef([AM_SILENT_RULES],


### PR DESCRIPTION
Enable common warnings in case logrotate gets not bootstrapped with the custom script autogen.sh, which uses `--warnings=all`.
Enable the target `installcheck` to verify all installed binaries support the common arguments `--help` and `--version`.

See https://www.gnu.org/software/automake/manual/html_node/List-of-Automake-options.html