### PR TITLE
Do not warn on key value pair separated by only an equal sign

### DIFF
--- a/config.c
+++ b/config.c
@@ -1109,7 +1109,7 @@ static int readConfigFile(const char *configFile, struct logInfo *defConfig)
                                 configFile, lineNum);
                         continue;
                     }
-                    if (!isspace((unsigned char)*start)) {
+                    if (!isspace((unsigned char)*start) && *start != '=') {
                         message(MESS_NORMAL, "%s:%d keyword '%s' not properly"
                                 " separated, found %#x\n",
                                 configFile, lineNum, key, *start);


### PR DESCRIPTION
Do not warn if a configuration directive is specified with the key and
value separated by just an equal sign, like:

    size=+2048k

The warning is intended for the usage of:

    size2048k

Fixes: 2b588b5e ("Log if keyword is not properly separated")
Fixes: #410