### PR TITLE
Assert valid fd in shred_file when shredding

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -1,4 +1,5 @@
 #include "queue.h"
+#include <assert.h>
 #include <limits.h>
 #include <ctype.h>
 #include <dirent.h>
@@ -691,6 +692,9 @@ static int shred_file(int fd, const char *filename, const struct logInfo *log)
     if (!(log->flags & LOG_FLAG_SHRED)) {
         goto unlink_file;
     }
+
+    assert(fd >= 0);
+    assert( ({ int r_ = fcntl(fd, F_GETFL); r_ >= 0 && (r_ & (O_WRONLY | O_RDWR)); }) );
 
     if (!(log->flags & LOG_FLAG_ALLOWHARDLINK)) {
         struct stat sb;


### PR DESCRIPTION
Coverity gets confused when shred_file() is called from removeLogFile()
with LOG_FLAG_SHRED not set.  In this case shred_file() is passed an
invalid file descriptor but it gets never used.
Add an assert statement to silence this false-positive.

    *** CID 372221:  Integer handling issues  (NEGATIVE_RETURNS)
    /logrotate.c: 779 in removeLogFile()
    773                 message(MESS_ERROR, "error opening %s: %s\n",
    774                         name, strerror(errno));
    775                 return 1;
    776             }
    777         }
    778
    >>>     CID 372221:  Integer handling issues  (NEGATIVE_RETURNS)
    >>>     "fd" is passed to a parameter that cannot be negative.
    779         if (!debug && shred_file(fd, name, log)) {
    780             message(MESS_ERROR, "Failed to remove old log %s: %s\n",
    781                     name, strerror(errno));
    782             result = 1;
    783         }
    784

Also assert that the file descriptor is eligible for modifying.