### PR TITLE
Fix full_write on incomplete write

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -1137,18 +1137,18 @@ static int is_nul (void const *buf, size_t bufsize)
 static size_t full_write(int fd, const void *buf, size_t count)
 {
     size_t total = 0;
-    const char *ptr = (const char *) buf;
+    const unsigned char *ptr = (const unsigned char *) buf;
 
     while (count > 0)
     {
         size_t n_rw;
         for (;;)
         {
-            n_rw = (size_t)write (fd, buf, count);
-            if (errno == EINTR)
+            n_rw = (size_t)write (fd, ptr, count);
+            if (n_rw == (size_t) -1 && errno == EINTR)
                 continue;
-            else
-                break;
+
+            break;
         }
         if (n_rw == (size_t) -1)
             break;


### PR DESCRIPTION
Currently on an incomplete write(3) the subsequent write(3) will again
use the same starting position in the given buffer, which was already
successfully written, leading to data corruption.

Found by clang-13

    logrotate.c:1140:17: warning: variable 'ptr' set but not used [-Wunused-but-set-variable]
    const char *ptr = (const char *) buf;
                ^

Fixes: f1dc0d9 ("Allow rotation of sparse files with copytruncate")