### PR TITLE
config.c: enforce stricter parsing of config files

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [UNRELEASED]
 
 [UNRELEASED]: https://github.com/logrotate/logrotate/compare/3.18.1...master
+  - enforce stricter parsing of configuration files
 
 ## [3.18.1] - 2021-05-21
   - fix memory leaks on error-handling paths (#383, #387)

--- a/config.c
+++ b/config.c
@@ -1107,12 +1107,13 @@ static int readConfigFile(const char *configFile, struct logInfo *defConfig)
                     if (key == NULL) {
                         message(MESS_ERROR, "%s:%d failed to parse keyword\n",
                                 configFile, lineNum);
-                        continue;
+                        RAISE_ERROR();
                     }
                     if (!isspace((unsigned char)*start) && *start != '=') {
-                        message(MESS_NORMAL, "%s:%d keyword '%s' not properly"
+                        message(MESS_ERROR, "%s:%d keyword '%s' not properly"
                                 " separated, found %#x\n",
                                 configFile, lineNum, key, *start);
+                        RAISE_ERROR();
                     }
                     if (!strcmp(key, "compress")) {
                         newlog->flags |= LOG_FLAG_COMPRESS;
@@ -2004,7 +2005,7 @@ duperror:
                     message(MESS_ERROR, "%s:%d lines must begin with a keyword "
                             "or a filename (possibly in double quotes)\n",
                             configFile, lineNum);
-                    state = STATE_SKIP_LINE;
+                    RAISE_ERROR();
                 }
                 break;
             case STATE_SKIP_LINE:

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -91,7 +91,9 @@ TEST_CASES = \
 	test-0090.sh \
 	test-0091.sh \
 	test-0100.sh \
-	test-0101.sh
+	test-0101.sh \
+	test-0102.sh \
+	test-0103.sh
 
 EXTRA_DIST = \
 	compress \

--- a/test/test-0102.sh
+++ b/test/test-0102.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+. ./test-common.sh
+
+cleanup 102
+
+# ------------------------------- Test 102 ------------------------------------
+# test invalid config file with binary content
+preptest test.log 102 1
+
+$RLR test-config.102 --force
+
+if [ $? -eq 0 ]; then
+   echo "No error, but there should be one."
+   exit 3
+fi

--- a/test/test-0103.sh
+++ b/test/test-0103.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+. ./test-common.sh
+
+cleanup 103
+
+# ------------------------------- Test 103 ------------------------------------
+# test invalid config file with unknown keywords
+preptest test.log 103 1
+
+$RLR test-config.103 --force
+
+if [ $? -eq 0 ]; then
+   echo "No error, but there should be one."
+   exit 3
+fi

--- a/test/test-config.102.in
+++ b/test/test-config.102.in
@@ -1,0 +1,10 @@
+ELF
+
+&DIR&/test.log {
+ daily
+ size=0
+
+firstaction
+ /bin/sh -c "echo test123"
+ endscript
+}

--- a/test/test-config.103.in
+++ b/test/test-config.103.in
@@ -1,0 +1,12 @@
+random noise
+a b c d
+a::x
+
+&DIR&/test.log {
+ daily
+ size=0
+
+firstaction
+ /bin/sh -c "echo test123"
+ endscript
+}


### PR DESCRIPTION
A number of recent exploits have abused logrotate's lax parsing of config files as an easy way to turn privileged file write bugs into code execution:
- https://alephsecurity.com/2021/10/20/sudump/
- https://flattsecurity.medium.com/cve-2020-15702-race-condition-vulnerability-in-handling-of-pid-by-apport-4047f2e00a67#e688
- https://alephsecurity.com/2021/02/16/apport-lpe/

These exploits depend on bugs in other parts of the OS (apport, kernel, ..) to write partially controlled files to the logrotate config directory. Targeting logrotate is highly useful for attackers, because it will ignore invalid parts of config files and continue parsing until it finds a valid configuration.
This behaviour makes exploitation of tricky bugs such as the linked coredump vulnerabilities much easier.

This PR enforces stricter parsing of config files, by turning some of the already existing parser warnings into hard errors. It does not have any effect on users using valid configuration files, but might be a breaking change for people relying on the current handling of invalid files. As current versions already print an error message when encountering such files, no widely used configurations should be affected. 

Overall, I think this would be a nice defense-in-depth change to improve the security of many downstream logrotate users. 


