### PR TITLE
config.c: enforce stricter parsing of config files [no. 2]

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -93,7 +93,9 @@ TEST_CASES = \
 	test-0100.sh \
 	test-0101.sh \
 	test-0102.sh \
-	test-0103.sh
+	test-0103.sh \
+	test-0104.sh \
+	test-0105.sh
 
 EXTRA_DIST = \
 	compress \

--- a/test/test-0102.sh
+++ b/test/test-0102.sh
@@ -14,3 +14,8 @@ if [ $? -eq 0 ]; then
    echo "No error, but there should be one."
    exit 3
 fi
+
+checkoutput <<EOF
+test.log 0 zero
+test.log.1 0 first
+EOF

--- a/test/test-0103.sh
+++ b/test/test-0103.sh
@@ -14,3 +14,8 @@ if [ $? -eq 0 ]; then
    echo "No error, but there should be one."
    exit 3
 fi
+
+checkoutput <<EOF
+test.log 0 zero
+test.log.1 0 first
+EOF

--- a/test/test-0104.sh
+++ b/test/test-0104.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+. ./test-common.sh
+
+cleanup 104
+
+# ------------------------------- Test 104 ------------------------------------
+# test config with unknown (new?) keyword
+preptest test1.log 104 1
+preptest test2.log 104 1
+
+$RLR test-config.104 --force || exit 23
+
+checkoutput <<EOF
+test1.log 0
+test1.log.1 0 zero
+test2.log 0
+test2.log.1 0 zero
+EOF

--- a/test/test-0105.sh
+++ b/test/test-0105.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+. ./test-common.sh
+
+cleanup 105
+
+# ------------------------------- Test 105 ------------------------------------
+# test config with garbage keyword bails out
+preptest test1.log 105 1
+preptest test2.log 105 1
+
+$RLR test-config.105 --force
+
+if [ $? -eq 0 ]; then
+   echo "No error, but there should be one."
+   exit 3
+fi
+
+
+checkoutput <<EOF
+test1.log 0 zero
+test1.log.1 0 first
+test2.log 0
+test2.log.1 0 zero
+EOF

--- a/test/test-config.104.in
+++ b/test/test-config.104.in
@@ -1,0 +1,8 @@
+&DIR&/test1.log {
+    newkeyword
+    rotate 1
+}
+
+&DIR&/test2.log {
+    rotate 1
+}

--- a/test/test-config.105.in
+++ b/test/test-config.105.in
@@ -1,0 +1,8 @@
+&DIR&/test1.log {
+    g@rbag€[]+#*
+    rotate 1
+}
+
+&DIR&/test2.log {
+    rotate 1
+}


### PR DESCRIPTION
Same code as #427, plus some more test cases.