### PR TITLE
Do not lock state file /dev/null

### DIFF
--- a/logrotate.8.in
+++ b/logrotate.8.in
@@ -76,7 +76,7 @@ log files.  To prevent parallel execution \fBlogrotate\fR by default
 acquires a lock on the state file, if it cannot be acquired \fBlogrotate\fR
 will exit with value 3.  The default state file is \fI@STATE_FILE_PATH@\fR.
 If \fI/dev/null\fR is given as the state file, then \fBlogrotate\fR will
-not try to write the state file.
+not try to lock or write the state file.
 
 .TP
 \fB\-\-skip-state-lock\fR

--- a/logrotate.c
+++ b/logrotate.c
@@ -3000,7 +3000,13 @@ static int readState(const char *stateFilename)
 
 static int lockState(const char *stateFilename, int skip_state_lock)
 {
-    int lockFd = open(stateFilename, O_RDWR | O_CLOEXEC);
+    int lockFd;
+
+    if (!strcmp(stateFilename, "/dev/null")) {
+        return 0;
+    }
+
+    lockFd = open(stateFilename, O_RDWR | O_CLOEXEC);
     if (lockFd == -1) {
         if (errno == ENOENT) {
             message(MESS_DEBUG, "Creating stub state file: %s\n",


### PR DESCRIPTION
#395 introduced `/dev/null` as supported state file path for cases when no state file is desired.

`lockState()` tries to open and lock the state file to avoid issues with concurrent instances, see #295.

Locking the character file `/dev/null` might either be not supported, e.g. on Debian GNU/Hurd (hurd-i386), nor not allowed, e.g. by SELinux.