### PR TITLE
drop world-readable permission on state file

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -2593,6 +2593,7 @@ static int writeState(const char *stateFilename)
     struct tm now;
     time_t now_time, last_time;
     char *prevCtx;
+    int force_mode = 0;
 
     if (!strcmp(stateFilename, "/dev/null"))
         /* explicitly asked not to write the state file */
@@ -2664,10 +2665,13 @@ static int writeState(const char *stateFilename)
 
     close(fdcurr);
 
-    /* drop world-readable flag to prevent others from locking */
-    sb.st_mode &= ~(mode_t)S_IROTH;
+    if (sb.st_mode & (mode_t)S_IROTH) {
+        /* drop world-readable flag to prevent others from locking */
+        sb.st_mode &= ~(mode_t)S_IROTH;
+        force_mode = 1;
+    }
 
-    fdsave = createOutputFile(tmpFilename, O_RDWR, &sb, prev_acl, 0);
+    fdsave = createOutputFile(tmpFilename, O_RDWR, &sb, prev_acl, force_mode);
 #ifdef WITH_ACL
     if (prev_acl) {
         acl_free(prev_acl);

--- a/test/test-0048.sh
+++ b/test/test-0048.sh
@@ -18,6 +18,7 @@ cat > state << EOF
 logrotate state -- version 2
 EOF
 
+chmod 0640 state
 setfacl -m u:nobody:rwx state
 
 $RLR test-config.48 || exit 23


### PR DESCRIPTION
... even when ACLs are enabled.  This is a follow-up to the fix
of CVE-2022-1348.  It has no impact on security but makes the state
file locking work again in more cases.