### PR TITLE
log: unify handling of log levels

### DIFF
--- a/config.c
+++ b/config.c
@@ -643,7 +643,7 @@ static void set_criterium(enum criterium *pDst, enum criterium src, int *pSet)
 {
     if (*pSet && (*pDst != src)) {
         /* we are overriding a previously set criterium */
-        message(MESS_VERBOSE, "warning: '%s' overrides previously specified '%s'\n",
+        message(MESS_DEBUG, "note: '%s' overrides previously specified '%s'\n",
                 crit_to_string(src), crit_to_string(*pDst));
     }
     *pDst = src;
@@ -1021,7 +1021,7 @@ static int readConfigFile(const char *configFile, struct logInfo *defConfig)
 
     if (getuid() == ROOT_UID) {
         if ((sb_config.st_mode & 07533) != 0400) {
-            message(MESS_NORMAL,
+            message(MESS_WARN,
                     "Potentially dangerous mode on %s: 0%o\n",
                     configFile, (unsigned) (sb_config.st_mode & 07777));
         }
@@ -1386,7 +1386,7 @@ static int readConfigFile(const char *configFile, struct logInfo *defConfig)
                             RAISE_ERROR();
                         }
                     } else if (!strcmp(key, "errors")) {
-                        message(MESS_NORMAL,
+                        message(MESS_WARN,
                                 "%s: %d: the errors directive is deprecated and no longer used.\n",
                                 configFile, lineNum);
                     } else if (!strcmp(key, "mail")) {

--- a/log.c
+++ b/log.c
@@ -40,9 +40,12 @@ static void log_once(FILE *where, int level, const char *format, va_list args)
 {
     switch (level) {
         case MESS_DEBUG:
-        case MESS_NORMAL:
-        case MESS_VERBOSE:
             break;
+
+        case MESS_WARN:
+            fprintf(where, "warning: ");
+            break;
+
         default:
             fprintf(where, "error: ");
             break;
@@ -78,9 +81,10 @@ void message(int level, const char *format, ...)
                 priority |= LOG_DEBUG;
                 break;
             case MESS_DEBUG:
-            case MESS_VERBOSE:
-            case MESS_NORMAL:
                 priority |= LOG_INFO;
+                break;
+            case MESS_WARN:
+                priority |= LOG_WARNING;
                 break;
             case MESS_ERROR:
                 priority |= LOG_ERR;

--- a/log.h
+++ b/log.h
@@ -5,8 +5,7 @@
 
 #define MESS_REALDEBUG  1
 #define MESS_DEBUG      2
-#define MESS_VERBOSE    3
-#define MESS_NORMAL     4
+#define MESS_WARN       4
 #define MESS_ERROR      5
 #define MESS_FATAL      6
 

--- a/logrotate.c
+++ b/logrotate.c
@@ -3050,7 +3050,7 @@ static int lockState(const char *stateFilename, int skip_state_lock)
     }
 
     if (sb.st_mode & S_IROTH) {
-        message(MESS_NORMAL, "warning: state file %s is world-readable"
+        message(MESS_WARN, "state file %s is world-readable"
                 " and thus can be locked from other unprivileged users."
                 " Skipping lock acquisition...\n",
                 stateFilename);
@@ -3106,7 +3106,7 @@ int main(int argc, const char **argv)
         POPT_AUTOHELP { NULL, 0, 0, NULL, 0, NULL, NULL }
     };
 
-    logSetLevel(MESS_NORMAL);
+    logSetLevel(MESS_WARN);
     setlocale (LC_ALL, "");
 
     optCon = poptGetContext("logrotate", argc, argv, options, 0);
@@ -3117,7 +3117,7 @@ int main(int argc, const char **argv)
         switch (arg) {
             case 'd':
                 debug = 1;
-                message(MESS_NORMAL, "WARNING: logrotate in debug mode does nothing"
+                message(MESS_WARN, "logrotate in debug mode does nothing"
                         " except printing debug messages!  Consider using verbose"
                         " mode (-v) instead if this is not what you want.\n\n");
                 /* fallthrough */

--- a/test/test-0080.sh
+++ b/test/test-0080.sh
@@ -10,4 +10,4 @@ cleanup 80
 preptest test.log 80 1 0
 
 $RLR -d test-config.80 2>&1 | \
-    grep -q "warning: 'daily' overrides previously specified 'size'"
+    grep -q "note: 'daily' overrides previously specified 'size'"


### PR DESCRIPTION
Use `MESS_WARN` instead of `MESS_NORMAL` and make it always use the `warning:` prefix.  Also drop `MESS_VERBOSE`, which was not set anywhere.