### PR TITLE
Reduce unnecessary rename operations in prerotateSingleLog()

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -2012,7 +2012,7 @@ static int prerotateSingleLog(const struct logInfo *log, unsigned logNum,
             return 1;
         }
 
-        for (i = rotateCount + logStart - 1; (i >= 0) && !hasErrors; i--) {
+        for (i = rotateCount + logStart - 1; (i >= logStart) && !hasErrors; i--) {
             free(newName);
             newName = oldName;
             if (asprintf(&oldName, "%s/%s.%d%s%s", rotNames->dirName,


### PR DESCRIPTION
config file:
```shell
[root@localhost logrotate]# cat logrotate.conf 
/root/logrotate_test/log/test.log
{
	su root root
	missingok
	size 100M
	rotate 3
	start 10
	copytruncate
	#dateext
	#dateformat _%Y%m%d_%s
}
```

before fixing: 
```shell
[root@localhost logrotate]# ./logrotate logrotate.conf -fv
reading config file logrotate.conf
Reading state from file: /var/lib/logrotate.status
Allocating hash table for state file, size 64 entries
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state

Handling 1 logs

rotating pattern: /root/logrotate_test/log/test.log
 forced from command line (3 rotations)
empty log files are rotated, old logs are removed
considering log /root/logrotate_test/log/test.log
  Now: 2022-06-11 10:43
  Last rotated at 2022-06-11 10:40
  log needs rotating
rotating log /root/logrotate_test/log/test.log, log->rotateCount is 3
dateext suffix '-20220611'
glob pattern '-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]'
renaming /root/logrotate_test/log/test.log.12 to /root/logrotate_test/log/test.log.13 (rotatecount 3, logstart 10, i 12), 
old log /root/logrotate_test/log/test.log.12 does not exist
renaming /root/logrotate_test/log/test.log.11 to /root/logrotate_test/log/test.log.12 (rotatecount 3, logstart 10, i 11), 
old log /root/logrotate_test/log/test.log.11 does not exist
renaming /root/logrotate_test/log/test.log.10 to /root/logrotate_test/log/test.log.11 (rotatecount 3, logstart 10, i 10), 
renaming /root/logrotate_test/log/test.log.9 to /root/logrotate_test/log/test.log.10 (rotatecount 3, logstart 10, i 9), 
old log /root/logrotate_test/log/test.log.9 does not exist
renaming /root/logrotate_test/log/test.log.8 to /root/logrotate_test/log/test.log.9 (rotatecount 3, logstart 10, i 8), 
old log /root/logrotate_test/log/test.log.8 does not exist
renaming /root/logrotate_test/log/test.log.7 to /root/logrotate_test/log/test.log.8 (rotatecount 3, logstart 10, i 7), 
old log /root/logrotate_test/log/test.log.7 does not exist
renaming /root/logrotate_test/log/test.log.6 to /root/logrotate_test/log/test.log.7 (rotatecount 3, logstart 10, i 6), 
old log /root/logrotate_test/log/test.log.6 does not exist
renaming /root/logrotate_test/log/test.log.5 to /root/logrotate_test/log/test.log.6 (rotatecount 3, logstart 10, i 5), 
old log /root/logrotate_test/log/test.log.5 does not exist
renaming /root/logrotate_test/log/test.log.4 to /root/logrotate_test/log/test.log.5 (rotatecount 3, logstart 10, i 4), 
old log /root/logrotate_test/log/test.log.4 does not exist
renaming /root/logrotate_test/log/test.log.3 to /root/logrotate_test/log/test.log.4 (rotatecount 3, logstart 10, i 3), 
old log /root/logrotate_test/log/test.log.3 does not exist
renaming /root/logrotate_test/log/test.log.2 to /root/logrotate_test/log/test.log.3 (rotatecount 3, logstart 10, i 2), 
old log /root/logrotate_test/log/test.log.2 does not exist
renaming /root/logrotate_test/log/test.log.1 to /root/logrotate_test/log/test.log.2 (rotatecount 3, logstart 10, i 1), 
old log /root/logrotate_test/log/test.log.1 does not exist
renaming /root/logrotate_test/log/test.log.0 to /root/logrotate_test/log/test.log.1 (rotatecount 3, logstart 10, i 0), 
old log /root/logrotate_test/log/test.log.0 does not exist
log /root/logrotate_test/log/test.log.13 doesn't exist -- won't try to dispose of it
copying /root/logrotate_test/log/test.log to /root/logrotate_test/log/test.log.10
truncating /root/logrotate_test/log/test.log

```

after fixing:
```shell
[root@localhost logrotate]# ./logrotate logrotate.conf -fv
reading config file logrotate.conf
warning: state file /var/lib/logrotate.status is world-readable and thus can be locked from other unprivileged users. Skipping lock acquisition...
Reading state from file: /var/lib/logrotate.status
Allocating hash table for state file, size 64 entries
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state
Creating new state

Handling 1 logs

rotating pattern: /root/logrotate_test/log/test.log
 forced from command line (3 rotations)
empty log files are rotated, old logs are removed
considering log /root/logrotate_test/log/test.log
  Now: 2022-06-11 11:12
  Last rotated at 2022-06-11 10:43
  log needs rotating
rotating log /root/logrotate_test/log/test.log, log->rotateCount is 3
dateext suffix '-20220611'
glob pattern '-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]'
renaming /root/logrotate_test/log/test.log.12 to /root/logrotate_test/log/test.log.13 (rotatecount 3, logstart 10, i 12), 
old log /root/logrotate_test/log/test.log.12 does not exist
renaming /root/logrotate_test/log/test.log.11 to /root/logrotate_test/log/test.log.12 (rotatecount 3, logstart 10, i 11), 
renaming /root/logrotate_test/log/test.log.10 to /root/logrotate_test/log/test.log.11 (rotatecount 3, logstart 10, i 10), 
log /root/logrotate_test/log/test.log.13 doesn't exist -- won't try to dispose of it
copying /root/logrotate_test/log/test.log to /root/logrotate_test/log/test.log.10
truncating /root/logrotate_test/log/test.log

```