### PR TITLE
Support home dir expansion in olddir

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -96,7 +96,8 @@ TEST_CASES = \
 	test-0102.sh \
 	test-0103.sh \
 	test-0104.sh \
-	test-0105.sh
+	test-0105.sh \
+	test-0106.sh
 
 EXTRA_DIST = \
 	compress \

--- a/test/test-0018.sh
+++ b/test/test-0018.sh
@@ -30,7 +30,7 @@ if [ $? = 0 ]; then
 	fi
 fi
 if [ $SYSLOG_TESTS = 1 ]; then
-	journalctl -n 50 2>/dev/null|grep $PWD/test.log.1 2>/dev/null >/dev/null
+	journalctl -n 100 2>/dev/null|grep "$PWD/test.log.1" 2>/dev/null >/dev/null
 	if [ $? != 0 ]; then
 		echo "syslog message not found"
 		exit 1

--- a/test/test-0106.sh
+++ b/test/test-0106.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+. ./test-common.sh
+
+cleanup 106
+
+# ------------------------------- Test 106 ------------------------------------
+# test ~ replacement in include and olddir directives
+preptest test.log 106 1
+
+export HOME="$(pwd)/homedir"
+rm -rf homedir/
+mkdir -p homedir/includedir
+cat > homedir/includedir/test-0106-included.conf << EOF
+$(pwd)/test.log {
+  rotate 1
+  create
+  olddir ~/old
+  createolddir 700
+}
+EOF
+chmod go-w homedir/includedir/test-0106-included.conf
+
+$RLR test-config.106 --force || exit 23
+
+checkoutput <<EOF
+test.log 0
+homedir/old/test.log.1 0 zero
+EOF
+
+rm -r homedir/

--- a/test/test-config.106.in
+++ b/test/test-config.106.in
@@ -1,0 +1,1 @@
+include ~/includedir


### PR DESCRIPTION
Support expanding paths leading with ~/ in olddir, similar to include.

Closes: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1015964