### PR TITLE
Avoid operating in insecure directories

### DIFF
--- a/config.c
+++ b/config.c
@@ -1285,6 +1285,10 @@ static int readConfigFile(const char *configFile, struct logInfo *defConfig)
                         newlog->flags |= LOG_FLAG_ALLOWHARDLINK;
                     } else if (!strcmp(key, "noallowhardlink")) {
                         newlog->flags &= ~LOG_FLAG_ALLOWHARDLINK;
+                    } else if (!strcmp(key, "allownonsecuredir")) {
+                        newlog->flags |= LOG_FLAG_ALLOWNONSECUREDIR;
+                    } else if (!strcmp(key, "noallownonsecuredir")) {
+                        newlog->flags &= ~LOG_FLAG_ALLOWNONSECUREDIR;
                     } else if (!strcmp(key, "sharedscripts")) {
                         newlog->flags |= LOG_FLAG_SHAREDSCRIPTS;
                     } else if (!strcmp(key, "nosharedscripts")) {
@@ -2112,6 +2116,7 @@ duperror:
                             const char *dirName;
                             struct stat sb_logdir;
                             struct stat sb_olddir;
+                            int rc;
 
                             dirpath = strdup(newlog->files[j]);
                             if (dirpath == NULL) {
@@ -2194,7 +2199,28 @@ duperror:
                                 }
                             }
 
-                            free(ld);
+                            /* Check if olddir and its parents of this log have safe permissions */
+                            rc = checkIsSecureDir(dirName, newlog);
+                            if (rc < 0 && (rc != -ENOENT || (newlog->flags & LOG_FLAG_OLDDIRCREATE) == 0)) {
+                                message(MESS_ERROR, "%s:%d failed checking whether olddir %s is a secure dir: %s\n",
+                                        configFile, lineNum, dirName, strerror(-rc));
+                                free(ld);
+                                goto error;
+                            }
+                            if (rc == 0) {
+                                message(MESS_ERROR, "%s:%d olddir %s or one of its parent"
+                                        " directories for log file %s has insecure permissions"
+                                        " (It's world writable or writable by a user or group"
+                                        " which is not \"root\")"
+                                        " Set \"su\" directive in config file to tell"
+                                        " logrotate which user/group should be used for"
+                                        " rotation.\n",
+                                        configFile, lineNum, dirName, newlog->files[j]);
+                                free(ld);
+                                goto error;
+                            }
+
+                            free(ld);  /* free after last usage of dirName */
 
                             if (sb_logdir.st_dev != sb_olddir.st_dev
                                     && !(newlog->flags & (LOG_FLAG_COPYTRUNCATE | LOG_FLAG_COPY | LOG_FLAG_TMPFILENAME))) {

--- a/logrotate.8.in
+++ b/logrotate.8.in
@@ -518,6 +518,23 @@ caution, especially when the log files are rotated as root.
 \fBnoallowhardlink\fR
 Do not rotate files with multiple hard links.  See also \fBallowhardlink\fR.
 
+.TP
+\fBallownonsecuredir\fR
+Rotate files inside insecure directories or into insecure \fBolddir\fR
+directories; this is off by default.  A directory is considered insecure if
+the directory or any of its parents is owned by a foreign non-root user or it
+is group-writable and owned by a foreign non-root group or it is
+world-writable and the sticky-bit is not set.  Operating in such a directory
+can lead to privilege escalation as the path might be redirected by an
+unprivileged user.  In most cases for such directories the privileges should
+be dropped via the \fBsu\fR directive.  Use with caution, especially when the
+log files are rotated as root.
+
+.TP
+\fBnoallownonsecuredir\fR
+Do not rotate files inside insecure directories or into insecure \fBolddir\fR
+directories.  This is the default.  See also \fBallownonsecuredir\fR.
+
 .SS Compression
 
 .TP

--- a/logrotate.c
+++ b/logrotate.c
@@ -54,6 +54,11 @@ static acl_type prev_acl = NULL;
 #define STATEFILE_BUFFER_SIZE 4096
 #endif
 
+/* XSI option: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_stat.h.html */
+#ifndef S_ISVTX
+#define S_ISVTX 01000
+#endif
+
 #ifdef __hpux
 extern int asprintf(char **str, const char *fmt, ...);
 #endif
@@ -1411,6 +1416,103 @@ static int last_day_of_month(const struct tm *now)
     return now->tm_mon != tomorrow.tm_mon;
 }
 
+static int isSecureDir(const char *pathname, uid_t exempt_uid, gid_t exempt_gid, int depth);
+
+static int isSecureDirStep(const char *pathname, uid_t exempt_uid, gid_t exempt_gid, int depth)
+{
+    struct stat sb;
+
+    if (lstat(pathname, &sb) < 0)
+        return -errno;
+
+    if (S_ISLNK(sb.st_mode)) {
+        /* check whether symlink target is inside a secure directory */
+        char *canonpath;
+        int r;
+
+        canonpath = realpath(pathname, NULL);
+        if (!canonpath)
+            return -errno;
+
+        r = isSecureDir(canonpath, exempt_uid, exempt_gid, depth + 1);
+        free(canonpath);
+        return r;
+    }
+
+    if (!S_ISDIR(sb.st_mode))
+        return -ENOTDIR;
+
+    if ((sb.st_uid != ROOT_UID && sb.st_uid != exempt_uid) ||
+        ((sb.st_mode & S_IWGRP) && sb.st_gid != ROOT_GID && sb.st_gid != exempt_gid) ||
+        (sb.st_mode & S_IWOTH && !(sb.st_mode & S_ISVTX))) {
+        return 0;
+    }
+
+    return 1;
+}
+
+static int isSecureDir(const char *pathname, uid_t exempt_uid, gid_t exempt_gid, int depth)
+{
+    char *copy, *p;
+    int r;
+
+    if (depth >= 10)
+        return -ELOOP;
+
+    if (pathname[0] != '/')
+        return -EINVAL;
+
+    copy = strdup(pathname);
+    if (!copy)
+        return -errno;
+
+    p = copy + 1;
+    for (;;) {
+        char backup = '\0'; /* initialize to please GCC */
+        int last = (p == NULL || *p == '\0');
+
+        if (!last) {
+            backup = *p;
+            *p = '\0';
+        }
+
+        r = isSecureDirStep(copy, exempt_uid, exempt_gid, depth);
+        if (r <= 0 || last)
+            break;
+
+        *p = backup;
+        p = strchr(p + 1, '/');
+    }
+
+    free(copy);
+    return r;
+}
+
+/*
+ * Check whether the given path is a secure directory.
+ *
+ * Return 1 if the check passes,
+ *        0 if the check fails or
+ *        <0 negative errno style value on error.
+ */
+int checkIsSecureDir(const char *pathname, const struct logInfo *log)
+{
+    uid_t exempt_uid;
+    gid_t exempt_gid;
+
+    if (log->flags & LOG_FLAG_ALLOWNONSECUREDIR)
+        return 1;
+
+    if (getuid() != ROOT_UID && geteuid() != ROOT_UID &&
+        getgid() != ROOT_GID && getegid() != ROOT_GID)
+        return 1;
+
+    exempt_uid = (log->flags & LOG_FLAG_SU) ? log->suUid : ROOT_UID;
+    exempt_gid = (log->flags & LOG_FLAG_SU) ? log->suGid : ROOT_GID;
+
+    return isSecureDir(pathname, exempt_uid, exempt_gid, 0);
+}
+
 static int findNeedRotating(const struct logInfo *log, unsigned logNum, int force)
 {
     struct stat sb;
@@ -1421,39 +1523,38 @@ static int findNeedRotating(const struct logInfo *log, unsigned logNum, int forc
 
     localtime_r(&nowSecs, &now);
 
-    /* Check if parent directory of this log has safe permissions */
-    if ((log->flags & LOG_FLAG_SU) == 0 && getuid() == ROOT_UID) {
-        char *ld;
-        char *logpath = strdup(log->files[logNum]);
-        if (logpath == NULL) {
+    /* Check if parent directories of this log has safe permissions */
+    {
+        char *logpath;
+        const char *logdir;
+        int r;
+
+        logpath = strdup(log->files[logNum]);
+        if (!logpath) {
             message_OOM();
             return 1;
         }
-        ld = dirname(logpath);
-        if (stat(ld, &sb)) {
+        logdir = dirname(logpath);
+        r = checkIsSecureDir(logdir, log);
+        free(logpath);
+        if (r < 0) {
             /* If parent directory doesn't exist, it's not real error
-               (unless nomissingok is specified)
-               and rotation is not needed */
-            if (errno != ENOENT || (log->flags & LOG_FLAG_MISSINGOK) == 0) {
-                message(MESS_ERROR, "stat of %s failed: %s\n", ld,
-                        strerror(errno));
-                free(logpath);
-                return 1;
-            }
-            free(logpath);
-            return 0;
+             * (unless nomissingok is specified) and rotation is not needed */
+            if (r == -ENOENT && (log->flags & LOG_FLAG_MISSINGOK))
+                return 0;
+
+            message(MESS_ERROR, "failed checking whether log file %s is located in a secure dir: %s\n",
+                    log->files[logNum], strerror(-r));
+            return 1;
         }
-        /* Don't rotate in directories writable by others or group which is not "root"  */
-        if ((sb.st_gid != 0 && (sb.st_mode & S_IWGRP)) || (sb.st_mode & S_IWOTH)) {
-            message(MESS_ERROR, "skipping \"%s\" because parent directory has insecure permissions"
-                    " (It's world writable or writable by group which is not \"root\")"
+        if (r == 0) {
+            message(MESS_ERROR, "skipping \"%s\" because a parent directory has insecure permissions"
+                    " (It's world writable or writable by a user or group which is not \"root\")"
                     " Set \"su\" directive in config file to tell logrotate which user/group"
                     " should be used for rotation.\n"
                     ,log->files[logNum]);
-            free(logpath);
             return 1;
         }
-        free(logpath);
     }
 
     if (lstat(log->files[logNum], &sb)) {

--- a/logrotate.h
+++ b/logrotate.h
@@ -11,28 +11,32 @@
 #   include <libgen.h>
 #endif
 
-#define LOG_FLAG_COMPRESS         (1U << 0)
-#define LOG_FLAG_CREATE           (1U << 1)
-#define LOG_FLAG_IFEMPTY          (1U << 2)
-#define LOG_FLAG_DELAYCOMPRESS    (1U << 3)
-#define LOG_FLAG_COPYTRUNCATE     (1U << 4)
-#define LOG_FLAG_MISSINGOK        (1U << 5)
-#define LOG_FLAG_MAILFIRST        (1U << 6)
-#define LOG_FLAG_SHAREDSCRIPTS    (1U << 7)
-#define LOG_FLAG_COPY             (1U << 8)
-#define LOG_FLAG_DATEEXT          (1U << 9)
-#define LOG_FLAG_SHRED            (1U << 10)
-#define LOG_FLAG_SU               (1U << 11)
-#define LOG_FLAG_DATEYESTERDAY    (1U << 12)
-#define LOG_FLAG_OLDDIRCREATE     (1U << 13)
-#define LOG_FLAG_TMPFILENAME      (1U << 14)
-#define LOG_FLAG_DATEHOURAGO      (1U << 15)
-#define LOG_FLAG_ALLOWHARDLINK    (1U << 16)
-#define LOG_FLAG_IGNOREDUPLICATES (1U << 17)
+#define LOG_FLAG_COMPRESS          (1U << 0)
+#define LOG_FLAG_CREATE            (1U << 1)
+#define LOG_FLAG_IFEMPTY           (1U << 2)
+#define LOG_FLAG_DELAYCOMPRESS     (1U << 3)
+#define LOG_FLAG_COPYTRUNCATE      (1U << 4)
+#define LOG_FLAG_MISSINGOK         (1U << 5)
+#define LOG_FLAG_MAILFIRST         (1U << 6)
+#define LOG_FLAG_SHAREDSCRIPTS     (1U << 7)
+#define LOG_FLAG_COPY              (1U << 8)
+#define LOG_FLAG_DATEEXT           (1U << 9)
+#define LOG_FLAG_SHRED             (1U << 10)
+#define LOG_FLAG_SU                (1U << 11)
+#define LOG_FLAG_DATEYESTERDAY     (1U << 12)
+#define LOG_FLAG_OLDDIRCREATE      (1U << 13)
+#define LOG_FLAG_TMPFILENAME       (1U << 14)
+#define LOG_FLAG_DATEHOURAGO       (1U << 15)
+#define LOG_FLAG_ALLOWHARDLINK     (1U << 16)
+#define LOG_FLAG_IGNOREDUPLICATES  (1U << 17)
+#define LOG_FLAG_ALLOWNONSECUREDIR (1U << 18)
 
 #define NO_MODE ((mode_t) -1)
 #define NO_UID  ((uid_t) -1)
 #define NO_GID  ((gid_t) -1)
+
+/* ROOT_UID comes from config.h (see configure.ac); mirror it for the group id. */
+#define ROOT_GID ((gid_t) 0)
 
 #ifdef HAVE_LIBSELINUX
 #define WITH_SELINUX 1
@@ -100,6 +104,7 @@ extern int debug;
 
 int switch_user(uid_t user, gid_t group);
 int switch_user_back(void);
+int checkIsSecureDir(const char *pathname, const struct logInfo *log);
 int readAllConfigPaths(const char **paths);
 #if !defined(asprintf) && !defined(_FORTIFY_SOURCE)
 int asprintf(char **string_ptr, const char *format, ...);


### PR DESCRIPTION
Logrotate is known to be affected by race conditions when operating
on files in "insecure" directories[1].  Since logrotate is commonly run
as root this can lead to privilege escalation[2,3].

Ensure log and olddir directories are "secure"[4], i.e. owned by a
foreign non-root user or group-writable and owned by a foreign non-root
user or world-writable and sticky-bit not set.

Add a new directive 'allownonsecuredir' as last resort to allow rotation
in such directories.

[1]: https://github.com/whotwagner/logrotten
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=1705143
[3]: https://gitlab.com/gitlab-org/omnibus-gitlab/-/issues/4380
[4]: https://wiki.sei.cmu.edu/confluence/display/c/FIO15-C.+Ensure+that+file+operations+are+performed+in+a+secure+directory

Supersedes: https://github.com/logrotate/logrotate/pull/237