### PR TITLE
Add Shell linter - Differential-ShellCheck

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+---
+
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    labels:
+      - 'type: dependencies'
+      - 'github-actions'

--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -1,0 +1,28 @@
+---
+
+name: Differential ShellCheck
+on:
+  pull_request:
+    branches: [ master ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+
+    permissions:
+      security-events: write
+      pull-requests: write
+
+    steps:
+      - name: Repository checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          fetch-depth: 0
+
+      - name: Differential ShellCheck
+        uses: redhat-plumbers-in-action/differential-shellcheck@4c86d15d8298bd82997991770fe0609860e11474
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/test/test-common-acl.sh
+++ b/test/test-common-acl.sh
@@ -1,3 +1,5 @@
+# shellcheck shell=sh
+
 # We test if the ACLs tests should be done or not
 
 if [ -z "$ACL_TESTS" ]; then

--- a/test/test-common-selinux.sh
+++ b/test/test-common-selinux.sh
@@ -1,3 +1,5 @@
+# shellcheck shell=sh
+
 # We test if the SELinux tests should be done or not
 
 if [ -z "$SELINUX_TESTS" ]; then

--- a/test/test-common.sh
+++ b/test/test-common.sh
@@ -1,3 +1,5 @@
+# shellcheck shell=sh
+
 # common variables and functions for legacy tests
 
 if readlink -f $LOGROTATE > /dev/null 2>&1; then


### PR DESCRIPTION
Differential ShellCheck is a GitHub action that performs differential ShellCheck scans on files changed via PR and reports results directly in PR.

Since this repository contains a lot of shell scripts I think you might find it useful.

Documentation is available at: [@redhat-plumbers-in-action/differential-shellcheck](https://github.com/redhat-plumbers-in-action/differential-shellcheck#readme). Let me know If you are missing some feature or setting.

/cc @kdudka 