### PR TITLE
Timestamp updating improvements

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -168,6 +168,7 @@ AC_DEFINE_UNQUOTED([ROOT_UID], [0], [Root user-id.])
 AC_SUBST(ROOT_UID)
 
 AC_CHECK_FUNCS([asprintf madvise secure_getenv strndup utimensat vsyslog])
+AC_CHECK_MEMBERS([struct stat.st_atim, struct stat.st_mtim])
 AC_CONFIG_HEADERS([config.h])
 
 AM_CFLAGS="\

--- a/configure.ac
+++ b/configure.ac
@@ -167,7 +167,7 @@ AC_SUBST(COMPRESS_EXT)
 AC_DEFINE_UNQUOTED([ROOT_UID], [0], [Root user-id.])
 AC_SUBST(ROOT_UID)
 
-AC_CHECK_FUNCS([asprintf madvise secure_getenv strndup utimensat vsyslog])
+AC_CHECK_FUNCS([asprintf futimens madvise secure_getenv strndup utimensat vsyslog])
 AC_CHECK_MEMBERS([struct stat.st_atim, struct stat.st_mtim])
 AC_CONFIG_HEADERS([config.h])
 

--- a/logrotate.c
+++ b/logrotate.c
@@ -790,7 +790,7 @@ static void setAtimeMtime(const char *filename, const struct stat *sb)
     /* If we can't change atime/mtime, it's not a disaster.  It might
        possibly fail under SELinux. But do try to preserve the
        fractional part if we have utimensat(). */
-#if defined HAVE_UTIMENSAT && !defined(__APPLE__)
+#if defined HAVE_UTIMENSAT && defined HAVE_STRUCT_STAT_ST_ATIM && defined HAVE_STRUCT_STAT_ST_MTIM
     struct timespec ts[2];
 
     ts[0] = sb->st_atim;

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -99,7 +99,8 @@ TEST_CASES = \
 	test-0104.sh \
 	test-0105.sh \
 	test-0106.sh \
-	test-0107.sh
+	test-0107.sh \
+	test-0108.sh
 
 EXTRA_DIST = \
 	compress \

--- a/test/test-0108.sh
+++ b/test/test-0108.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+. ./test-common.sh
+
+cleanup 108
+
+# ------------------------------- Test 108 ------------------------------------
+# test setting atime and time on compressed files
+preptest test.log 108 0
+
+checkoutput <<EOF
+test.log 0 zero
+EOF
+
+# Set log modification time to some date in the past
+TZ=UTC touch -t 200001010000 test.log
+
+$RLR test-config.108 --force || exit 23
+
+atime=$($STAT_ATIME_FORMAT test.log.1.gz)
+mtime=$($STAT_MTIME_FORMAT test.log.1.gz)
+expected_time=946684800
+
+if [ "$atime" -ne $expected_time ]; then
+    echo "atime not set (expected $expected_time, got $atime)" >&2
+    exit 3
+fi
+
+if [ "$mtime" -ne $expected_time ]; then
+    echo "mtime not set (expected $expected_time, got $mtime)" >&2
+    exit 3
+fi
+
+# check last, to not modify atime
+checkoutput <<EOF
+test.log 0
+test.log.1.gz 1 zero
+EOF

--- a/test/test-common.sh
+++ b/test/test-common.sh
@@ -37,8 +37,12 @@ fi
 
 if stat -c %f $LOGROTATE > /dev/null 2>&1; then
   STAT_MODE_FORMAT='stat -c %f'
+  STAT_ATIME_FORMAT='stat -c %X'
+  STAT_MTIME_FORMAT='stat -c %Y'
 elif stat -f %Xp $LOGROTATE > /dev/null 2>&1; then
   STAT_MODE_FORMAT='stat -f %Xp'
+  STAT_ATIME_FORMAT='stat -f %a'
+  STAT_MTIME_FORMAT='stat -f %m'
 else
   echo "no stat format option found:"
   stat -c %f $LOGROTATE

--- a/test/test-config.108.in
+++ b/test/test-config.108.in
@@ -1,0 +1,6 @@
+&DIR&/test.log {
+    create
+    compress
+    daily
+    rotate 1
+}


### PR DESCRIPTION
* test: check atime and mtime are set after compression

* clarify conditional usage of utimensat

  Commit https://github.com/logrotate/logrotate/commit/0d805cee34d3a9b1937130fb7c7fcf75d940f51f ("logrotate: do not use utimensat() on Darwin") disabled
the usage of utimensat(3) on Darwin.  The actual issue was not the libc
call of utimensat(3), but the more precise struct `stat` members `st_atim`
and `st_mtim`.  Check for those struct members at configure time and
avoid using a general conditional check against `__APPLE__`.

* update file timestamps via descriptor if possible

  Update the atime and mtime of newly created compressed rotated log files
via the race free function futimens(3) (if available).  Also use the
flag AT_SYMLINK_NOFOLLOW to not dereference symlinks via utimensat(3).

  This should prevent theoretical race conditions with regard to the underlying file.