### PR TITLE
shellcheck: suppress warnings about unused variables in test-common.sh

### DIFF
--- a/test/test-common.sh
+++ b/test/test-common.sh
@@ -1,4 +1,4 @@
-# shellcheck shell=sh
+# shellcheck shell=sh disable=SC2034
 
 # common variables and functions for legacy tests
 


### PR DESCRIPTION
This is a sourced script and the variables are used by other scripts that source it.

```
test/test-common.sh:16: warning[SC2034]: RLR appears unused. Verify use (or export if used externally).
test/test-common.sh:26: warning[SC2034]: DU_APPARENT_SIZE appears unused. Verify use (or export if used externally).
test/test-common.sh:43: warning[SC2034]: STAT_MODE_FORMAT appears unused. Verify use (or export if used externally).
test/test-common.sh:44: warning[SC2034]: STAT_ATIME_FORMAT appears unused. Verify use (or export if used externally).
test/test-common.sh:45: warning[SC2034]: STAT_MTIME_FORMAT appears unused. Verify use (or export if used externally).
```