### PR TITLE
Reorder file size cast

### DIFF
--- a/config.c
+++ b/config.c
@@ -1075,14 +1075,14 @@ static int readConfigFile(const char *configFile, struct logInfo *defConfig)
         }
     }
 
-    length = (size_t)sb_config.st_size;
-
-    if (length > 0xffffff) {
+    if (sb_config.st_size > 0xffffff) {
         message(MESS_ERROR, "file %s too large, probably not a config file.\n",
                 configFile);
         close(fd);
         return 1;
     }
+
+    length = (size_t)sb_config.st_size;
 
     /* We can't mmap empty file... */
     if (length == 0) {


### PR DESCRIPTION
Check first for large file sizes and cast to size_t afterwards, since on 32bit systems off_t might have a size of 8 byte, whereby size_t is 4 byte.