### PR TITLE
ci: trigger `differential-shellcheck` workflow on push

### DIFF
--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -15,7 +15,6 @@ jobs:
 
     permissions:
       security-events: write
-      pull-requests: write
 
     steps:
       - name: Repository checkout

--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -2,6 +2,7 @@
 
 name: Differential ShellCheck
 on:
+  push:
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
Fixes: https://github.com/redhat-plumbers-in-action/differential-shellcheck/issues/215

This should get rid of annoying messages from the `github-code-scanning` bot.

![Screenshot from 2023-03-22 07-00-32](https://user-images.githubusercontent.com/2879818/226815668-36272095-4f1d-4465-a0e8-f317b0abfc52.png)