### PR TITLE
ci: drop ubuntu-18.04 and add ubuntu-22.04

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         cc: [ gcc, clang ]
-        os: [ ubuntu-18.04, ubuntu-20.04 ]
+        os: [ ubuntu-20.04, ubuntu-22.04 ]
     runs-on: ${{ matrix.os }}
     env:
       CC: ${{ matrix.cc }}


### PR DESCRIPTION
ubuntu-18.04 is going to be removed, see https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/