### PR TITLE
do not rotate old logs on prerotate failure

### DIFF
--- a/logrotate.8.in
+++ b/logrotate.8.in
@@ -702,8 +702,8 @@ the \fBSCRIPTS\fR section.
 \ \ \ \ \fIscript\fR
 .tq
 \fBendscript\fR
-The \fIscript\fR is executed before
-the log file is rotated and only if the log will actually be rotated.  These
+The \fIscript\fR is executed before the log file and its old logs are
+rotated and only if the log will actually be rotated.  These
 directives may only appear inside a log file definition.  Normally,
 the absolute path to the log file is passed as the first argument to the script.
 If \fBsharedscripts\fR is specified, the whole pattern is passed to the script.

--- a/logrotate.c
+++ b/logrotate.c
@@ -2476,10 +2476,6 @@ static int rotateLogSet(const struct logInfo *log, int force)
                 return 1;
             }
             memset(rotNames[i], 0, sizeof(struct logNames));
-
-            logHasErrors[i] |=
-                prerotateSingleLog(log, i, state[i], rotNames[i]);
-            hasErrors |= logHasErrors[i];
         }
 
         if (log->pre
@@ -2506,6 +2502,16 @@ static int rotateLogSet(const struct logInfo *log, int force)
                     logHasErrors[j] = 1;
                     hasErrors = 1;
                 }
+            }
+        }
+
+        for (i = j;
+             ((log->flags & LOG_FLAG_SHAREDSCRIPTS) && i < log->numFiles)
+             || (!(log->flags & LOG_FLAG_SHAREDSCRIPTS) && i == j); i++) {
+            if (! ( (logHasErrors[i] && !(log->flags & LOG_FLAG_SHAREDSCRIPTS))
+                    || (hasErrors && (log->flags & LOG_FLAG_SHAREDSCRIPTS)) ) ) {
+                logHasErrors[i] |= prerotateSingleLog(log, i, state[i], rotNames[i]);
+                hasErrors |= logHasErrors[i];
             }
         }
 

--- a/test/test-0109.sh
+++ b/test/test-0109.sh
@@ -79,13 +79,13 @@ $RLR -f test-config.109 && exit 23
 
 checkoutput <<EOF
 test-pre.log 0 zero
-test-pre.log.2 0 first
-test-pre.log.3 0 second
-test-pre.log.4 0 third
+test-pre.log.1 0 first
+test-pre.log.2 0 second
+test-pre.log.3 0 third
 EOF
 
-if [ -e test-pre.log.1 ]; then
-	echo "test-pre.log.1 exists"
+if [ -e test-pre.log.4 ]; then
+	echo "test-pre.log.4 exists"
 	exit 3
 fi
 
@@ -99,25 +99,25 @@ EOF
 
 checkoutput <<EOF
 test-shared-pre-A.log 0 zero
-test-shared-pre-A.log.2 0 first
-test-shared-pre-A.log.3 0 second
-test-shared-pre-A.log.4 0 third
+test-shared-pre-A.log.1 0 first
+test-shared-pre-A.log.2 0 second
+test-shared-pre-A.log.3 0 third
 EOF
 
-if [ -e test-shared-pre-A.log.1 ]; then
-	echo "test-shared-pre-A.log.1 exists"
+if [ -e test-shared-pre-A.log.4 ]; then
+	echo "test-shared-pre-A.log.4 exists"
 	exit 3
 fi
 
 checkoutput <<EOF
 test-shared-pre-B.log 0 zero
-test-shared-pre-B.log.2 0 first
-test-shared-pre-B.log.3 0 second
-test-shared-pre-B.log.4 0 third
+test-shared-pre-B.log.1 0 first
+test-shared-pre-B.log.2 0 second
+test-shared-pre-B.log.3 0 third
 EOF
 
-if [ -e test-shared-pre-B.log.1 ]; then
-	echo "test-shared-pre-B.log.1 exists"
+if [ -e test-shared-pre-B.log.4 ]; then
+	echo "test-shared-pre-B.log.4 exists"
 	exit 3
 fi
 


### PR DESCRIPTION
Ensures old logs are preserved and not rotated out for logs with a failing prerotate script.

Alternative to #502