### PR TITLE
Exit code equals 1 if configuration file is not owned by root

### DIFF
--- a/config.c
+++ b/config.c
@@ -1071,7 +1071,7 @@ static int readConfigFile(const char *configFile, struct logInfo *defConfig)
                     "Ignoring %s because the file owner is wrong (should be root or user with uid 0).\n",
                     configFile);
             close(fd);
-            return 0;
+            return 1;
         }
     }
 

--- a/config.c
+++ b/config.c
@@ -1743,7 +1743,7 @@ static int readConfigFile(const char *configFile, struct logInfo *defConfig)
                         message(MESS_DEBUG, "compress_ext is now %s\n",
                                 newlog->compress_ext);
                     } else {
-                        message(MESS_ERROR, "%s:%d unknown option '%s' "
+                        message(MESS_WARN, "%s:%d unknown option '%s' "
                                 "-- ignoring line\n", configFile, lineNum, key);
                         if (*start != '\n')
                             state = STATE_SKIP_LINE;

--- a/config.c
+++ b/config.c
@@ -1063,7 +1063,7 @@ static int readConfigFile(const char *configFile, struct logInfo *defConfig)
                     "Ignoring %s because it is writable by group or others.\n",
                     configFile);
             close(fd);
-            return 0;
+            return 1;
         }
 
         if (sb_config.st_uid != ROOT_UID) {


### PR DESCRIPTION
The [PR 448](https://github.com/logrotate/logrotate/pull/448) let me think the error messages strategy is:
MESS_ERROR if the error stops `logrotate`. So exit value should not be 0.
MESS_WARNING if it's possible to continue to run `logrotate`. Exit value is 0.

Currently, if configuration file is not owner by root, `logrotate` exits with 0 as exit code (it's in [confic.c](https://github.com/logrotate/logrotate/blob/master/config.c#L1070) ):

```C
message(MESS_ERROR,
    "Ignoring %s because the file owner is wrong (should be root or user with uid 0).\n",
    configFile);
```


```
$ sudo LANG=C ./logrotate logrotate.not_root.conf
error: Ignoring logrotate.not_root.conf because the file owner is wrong (should be root or user with uid 0).
$ echo $?
0
```

This PR changes the exit code to 1.


I found two cases where it should use `MESS_WARNING` because configuration lines are ignored:

1. [lines 342-343](https://github.com/logrotate/logrotate/blob/master/config.c#L342):
```C
message(MESS_ERROR, "%s:%d extra arguments for "
    "%s\n", configFile, lineNum, directive); 
```

```
$ sudo LANG=C ./logrotate logrotate.extra_argument.conf 
error: logrotate.extra_argument.conf:2 unknown option 'extraarg' -- ignoring line
$ echo $?
0
```


2. [lines 1746-1747](https://github.com/logrotate/logrotate/blob/master/config.c#L1746):
```C
message(MESS_ERROR, "%s:%d unknown option '%s' "
    "-- ignoring line\n", configFile, lineNum, key);
```

```
$ sudo LANG=C ./logrotate logrotate.invalid_directive.conf
error: logrotate.invalid_directive.conf:2 unknown option 'invaliddirective' -- ignoring line
$ echo $?
0
```

I can add them to the PR if you think it's the correct behavior.


Tests are all green. I didn't understand how to modify them to add exit value assertion and didn't find documentation about them. So, there is no additional test.