### PR TITLE
Restore old time_t difference calculations 

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -1352,7 +1352,7 @@ static time_t mktimeFromDateOnly(const struct tm *src)
 static long daysElapsed(const struct tm *now, const struct tm *last)
 {
     const double diff = difftime(mktimeFromDateOnly(now), mktimeFromDateOnly(last));
-    return (long) (diff / DAY_SECONDS);
+    return (long) ((intmax_t)diff / DAY_SECONDS);
 }
 
 static int findNeedRotating(const struct logInfo *log, unsigned logNum, int force)
@@ -1935,7 +1935,7 @@ static int prerotateSingleLog(const struct logInfo *log, unsigned logNum,
                     if (((globResult.gl_pathc >= (size_t)rotateCount) && (glob_count <= (globResult.gl_pathc - (size_t)rotateCount)))
                             || ((log->rotateAge > 0)
                                 &&
-                                ((difftime(nowSecs, fst_buf.st_mtime) / DAY_SECONDS)
+                                (((intmax_t)difftime(nowSecs, fst_buf.st_mtime) / DAY_SECONDS)
                                  > log->rotateAge))) {
                         if (mail_out != (size_t)-1) {
                             char *mailFilename =
@@ -2049,7 +2049,7 @@ static int prerotateSingleLog(const struct logInfo *log, unsigned logNum,
                     continue;
                 }
 
-                if ((difftime(nowSecs, fst_buf.st_mtime) / DAY_SECONDS) > log->rotateAge) {
+                if (((intmax_t)difftime(nowSecs, fst_buf.st_mtime) / DAY_SECONDS) > log->rotateAge) {
                     if (!hasErrors && log->logAddress)
                         hasErrors = mailLogWrapper(oldName, mailCommand,
                                                    logNum, log);

--- a/logrotate.c
+++ b/logrotate.c
@@ -1351,8 +1351,8 @@ static time_t mktimeFromDateOnly(const struct tm *src)
 /* return by how many days the date was advanced but ignore exact time */
 static long daysElapsed(const struct tm *now, const struct tm *last)
 {
-    const double diff = difftime(mktimeFromDateOnly(now),mktimeFromDateOnly(last));
-    return (long) (diff / (24 * 3600));
+    const double diff = difftime(mktimeFromDateOnly(now), mktimeFromDateOnly(last));
+    return (long) (diff / DAY_SECONDS);
 }
 
 static int findNeedRotating(const struct logInfo *log, unsigned logNum, int force)

--- a/test/test-0085.sh
+++ b/test/test-0085.sh
@@ -44,30 +44,6 @@ if [ -f test.log.2 ]; then
 fi
 
 # maxage should remove this file
-if [ -f test.log.5 ]; then
-    echo "test.log.5 not removed" >&2
-    exit 3
-fi
-
-# maxage should remove this file
-if [ -f test.log.6 ]; then
-    echo "test.log.6 not removed" >&2
-    exit 3
-fi
-
-# maxage should remove this file
-if [ -f test.log.7 ]; then
-    echo "test.log.7 not removed" >&2
-    exit 3
-fi
-
-# maxage should remove this file
-if [ -f test.log.8 ]; then
-    echo "test.log.8 not removed" >&2
-    exit 3
-fi
-
-# maxage should remove this file
 if [ -f test.log.9 ]; then
     echo "test.log.9 not removed" >&2
     exit 3
@@ -84,4 +60,8 @@ test.log 0
 test.log.1 0 content
 test.log.3 0 first
 test.log.4 0 second
+test.log.5 0 third
+test.log.6 0 fourth
+test.log.7 0 fifth
+test.log.8 0 sixth
 EOF

--- a/test/test-0085.sh
+++ b/test/test-0085.sh
@@ -5,17 +5,33 @@
 cleanup 85
 
 # ------------------------------- Test 85 ------------------------------------
-preptest test.log 85 0
+preptest test.log 85 9
 
 $RLR test-config.85 -f || exit 23
 
 checkoutput <<EOF
 test.log 0
 test.log.1 0 zero
+test.log.2 0 first
+test.log.3 0 second
+test.log.4 0 third
+test.log.5 0 fourth
+test.log.6 0 fifth
+test.log.7 0 sixth
+test.log.8 0 seventh
+test.log.9 0 eighth
 EOF
 
 # Set log modification time to some date in the past
-touch -t 200001010000 test.log.1
+touch -t 200001010000 test.log.1  # 1 Jan 2000
+touch -t "$($DATE_DATEARG @$(($(date +%s) - 12 * 60 * 60)) +%Y%m%d%H%M)" test.log.2  # -12H
+touch -t "$($DATE_DATEARG @$(($(date +%s) - 23 * 60 * 60)) +%Y%m%d%H%M)" test.log.3  # -23H
+touch -t "$($DATE_DATEARG @$(($(date +%s) - 24 * 60 * 60)) +%Y%m%d%H%M)" test.log.4  # -24H
+touch -t "$($DATE_DATEARG @$(($(date +%s) - 25 * 60 * 60)) +%Y%m%d%H%M)" test.log.5  # -25H
+touch -t "$($DATE_DATEARG @$(($(date +%s) - 36 * 60 * 60)) +%Y%m%d%H%M)" test.log.6  # -36H
+touch -t "$($DATE_DATEARG @$(($(date +%s) - 47 * 60 * 60)) +%Y%m%d%H%M)" test.log.7  # -47H
+touch -t "$($DATE_DATEARG @$(($(date +%s) - 48 * 60 * 60)) +%Y%m%d%H%M)" test.log.8  # -48H
+touch -t "$($DATE_DATEARG @$(($(date +%s) - 49 * 60 * 60)) +%Y%m%d%H%M)" test.log.9  # -49H
 
 echo "content" >> test.log
 
@@ -23,11 +39,49 @@ $RLR test-config.85 -f || exit 23
 
 # maxage should remove this file
 if [ -f test.log.2 ]; then
-    echo "log not removed" >&2
+    echo "test.log.2 not removed" >&2
+    exit 3
+fi
+
+# maxage should remove this file
+if [ -f test.log.5 ]; then
+    echo "test.log.5 not removed" >&2
+    exit 3
+fi
+
+# maxage should remove this file
+if [ -f test.log.6 ]; then
+    echo "test.log.6 not removed" >&2
+    exit 3
+fi
+
+# maxage should remove this file
+if [ -f test.log.7 ]; then
+    echo "test.log.7 not removed" >&2
+    exit 3
+fi
+
+# maxage should remove this file
+if [ -f test.log.8 ]; then
+    echo "test.log.8 not removed" >&2
+    exit 3
+fi
+
+# maxage should remove this file
+if [ -f test.log.9 ]; then
+    echo "test.log.9 not removed" >&2
+    exit 3
+fi
+
+# should never be created
+if [ -f test.log.10 ]; then
+    echo "test.log.10 exists" >&2
     exit 3
 fi
 
 checkoutput <<EOF
 test.log 0
 test.log.1 0 content
+test.log.3 0 first
+test.log.4 0 second
 EOF

--- a/test/test-common.sh
+++ b/test/test-common.sh
@@ -118,7 +118,7 @@ createlog() {
 	    what=seventh
 	    ;;
 	8)
-	    what=eight
+	    what=eighth
 	    ;;
 	9)
 	    what=ninth

--- a/test/test-common.sh
+++ b/test/test-common.sh
@@ -50,6 +50,19 @@ else
   exit 1
 fi
 
+# check for date(1) support of operating on a time given from the command
+# line instead of the current time. Necessary for test 0085.
+if date --date @42 +%Y%m%d%H%M > /dev/null 2>&1; then
+  DATE_DATEARG='date --date'
+elif gdate --date @42 +%Y%m%d%H%M > /dev/null 2>&1; then
+  DATE_DATEARG='gdate --date'
+else
+  echo "no date command supporting argument --date found:"
+  date --date @42 +%Y%m%d%H%M
+  gdate --date @42 +%Y%m%d%H%M
+  exit 1
+fi
+
 TESTDIR="$(basename "$0" .sh)"
 mkdir -p "$TESTDIR"
 cd "$TESTDIR" || exit $?


### PR DESCRIPTION
With the introduction of difftime(3) in commit https://github.com/logrotate/logrotate/commit/4eb3add422f7d50128600eae3c678370fddc2217 ("Use difftime
to compare time_t") to support platform with an unsigned time_t several
arithmetic operations and comparisons turned from integer to floating
point ones.  This can lead to different results since integer divisions
round down to the next integer while floating point divisions do not.

Cast the result of difftime(3) to intmax_t to revert back to integer
operations.

Fixes: https://github.com/logrotate/logrotate/commit/4eb3add422f7d50128600eae3c678370fddc2217 ("Use difftime to compare time_t")
Fixes: https://github.com/logrotate/logrotate/issues/514

Supersedes: #515

Additionally contains some test cases and minor changes.