### PR TITLE
test: use UTC0 to support GMT time zone changes

### DIFF
--- a/test/test-0108.sh
+++ b/test/test-0108.sh
@@ -13,7 +13,7 @@ test.log 0 zero
 EOF
 
 # Set log modification time to some date in the past
-TZ=UTC touch -t 200001010000 test.log
+TZ=UTC0 touch -t 200001010000 test.log
 
 $RLR test-config.108 --force || exit 23
 


### PR DESCRIPTION
Explicitly set the offset to 0 to avoid issues running in a GMT environment during the summer:

    atime not set (expected 946684800, got 946681200)
    FAIL test-0108.sh (exit status: 3)