### PR TITLE
Avoid writing state to non regular files

### DIFF
--- a/config.c
+++ b/config.c
@@ -668,7 +668,7 @@ static int readConfigPath(const char *path, struct logInfo *defConfig)
         unsigned files_count = 0, i;
         DIR *dirp;
 
-        if ((here = open(".", O_RDONLY)) == -1) {
+        if ((here = open(".", O_RDONLY | O_DIRECTORY)) == -1) {
             message(MESS_ERROR, "cannot open current directory: %s\n",
                     strerror(errno));
             return 1;


### PR DESCRIPTION
Prevent the usage of non-regular files as state file.  The state is not actually written to the file of arbitrary type but a regular temporary one, which gets renamed at the end.
For example an erroneous usage of `/dev/zero` (instead of `/dev/null`) leads to a replacement of the character device file `/dev/zero` by a regular one.