### PR TITLE
man: run the tbl preprocessor to silence groff warning

### DIFF
--- a/logrotate.8.in
+++ b/logrotate.8.in
@@ -1,3 +1,4 @@
+'\" t
 .TH LOGROTATE 8 "@VERSION@" "Linux" "System Administrator's Manual"
 .\" Per groff_man(7), the TQ macro should be copied from an-ext.tmac when
 .\" not running under groff.  That's not quite right; not all groff


### PR DESCRIPTION
Reported by Lintian:

    $ LC_ALL=C.UTF-8 MANROFFSEQ='' MANWIDTH=80 man --warnings -E UTF-8 -l -Tutf8 -Z ./logrotate.8 >/dev/null
    an.tmac:<standard input>:600: warning: tbl preprocessor failed, or it or soelim was not run; table(s) likely not rendered (TE macro called with TW register undefined)

See https://lists.debian.org/debian-devel/2023/08/msg00220.html