### PR TITLE
Copytruncate updates

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -2295,7 +2295,14 @@ static int postrotateSingleLog(const struct logInfo *log, unsigned logNum,
 
     if (!hasErrors && (log->flags & LOG_FLAG_COMPRESS) &&
             !(log->flags & LOG_FLAG_DELAYCOMPRESS)) {
-        hasErrors = compressLogFile(rotNames->finalName, log, &state->sb);
+        /* whether copying was skipped in rotateSingleLog() -> copyTruncate() */
+        int skipped_copy = (log->flags & (LOG_FLAG_COPYTRUNCATE | LOG_FLAG_COPY)) &&
+                           !(log->flags & LOG_FLAG_TMPFILENAME) &&
+                           !log->rotateCount &&
+                           !log->logAddress;
+
+        if (!skipped_copy)
+            hasErrors = compressLogFile(rotNames->finalName, log, &state->sb);
     }
 
     if (!hasErrors && log->logAddress) {

--- a/logrotate.c
+++ b/logrotate.c
@@ -2253,7 +2253,8 @@ static int rotateSingleLog(const struct logInfo *log, unsigned logNum,
                 && (log->flags & (LOG_FLAG_COPYTRUNCATE | LOG_FLAG_COPY))
                 && !(log->flags & LOG_FLAG_TMPFILENAME)) {
             hasErrors = copyTruncate(log->files[logNum], rotNames->finalName,
-                                     &state->sb, log, !log->rotateCount);
+                                     &state->sb, log,
+                                     !log->rotateCount && !log->logAddress);
         }
 
 #ifdef WITH_ACL


### PR DESCRIPTION
* Do not skip copy when mailing
   Do not skip copying the about to truncated file if the rotate count is 0 when the log content should be mailed.

* Skip compressing skipped copy
   Skip compressing the non existent file skipped during truncation under a rotate count of 0.

   Closes: #552