### PR TITLE
Auto detect if DST in effect for dateyesterday

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -1755,7 +1755,7 @@ static int prerotateSingleLog(const struct logInfo *log, unsigned logNum,
 
     /* Adjust "now" if we want yesterday's date */
     if (log->flags & LOG_FLAG_DATEYESTERDAY) {
-        now.tm_hour = 12; /* set hour to noon to work around DST issues */
+        now.tm_isdst = -1; /* determine whether DST is in effect at the specified time */
         now.tm_mday = now.tm_mday - 1;
         mktime(&now);
     }


### PR DESCRIPTION
Instead of setting the hour unconditionally to 12 (noon), let mktime(3) detect whether DST is in effect at the specific time.

Closes: #551