### PR TITLE
Assume 0755 mode for olddircreate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ Makefile.in
 /autom4te.cache/
 /compile
 /configure
+/configure~
 /cscope.out
 /depcomp
 /install-sh

--- a/config.c
+++ b/config.c
@@ -467,6 +467,10 @@ static int mkpath(const char *path, mode_t mode, uid_t uid, gid_t gid) {
         return 1;
     }
 
+	message(MESS_DEBUG, "creating new directory %s mode = 0%o uid = %d "
+			"gid = %d\n", path, (unsigned int) mode,
+			(int) uid, (int) gid);
+
     rv = 0;
     pp = copypath;
     while (rv == 0 && (sp = strchr(pp, '/')) != NULL) {
@@ -1294,6 +1298,9 @@ static int readConfigFile(const char *configFile, struct logInfo *defConfig)
                         rv = readModeUidGid(configFile, lineNum, key, "createolddir",
                                             &newlog->olddirMode, &newlog->olddirUid,
                                             &newlog->olddirGid);
+						if (newlog->olddirMode == NO_MODE) {
+							newlog->olddirMode = 0755;
+						}
                         if (rv == -1) {
                             RAISE_ERROR();
                         }

--- a/logrotate.8.in
+++ b/logrotate.8.in
@@ -415,14 +415,14 @@ file for the omitted attributes.  This option can be disabled using the
 New log files are not created (this overrides the \fBcreate\fR option).
 
 .TP
-\fBcreateolddir \fImode\fR \fIowner\fR \fIgroup\fR
+\fBcreateolddir \fImode\fR \fR[\fIowner\fR \fR[\fIgroup\fR]\fR], \fBcreateolddir \fR[\fIowner\fR \fR[\fIgroup\fR]\fR]
 If the directory specified by \fBolddir\fR directive does not exist, it is
 created. \fImode\fR specifies the mode for the \fBolddir\fR directory
 in octal (the same as \fBchmod\fR(2)), \fIowner\fR specifies the user
 who will own the \fBolddir\fR directory, and \fIgroup\fR specifies the group
 the \fBolddir\fR directory will belong to (see the section \fBUSER AND GROUP
 \fR for details).  This option can be disabled using
-the \fBnocreateolddir\fR option.
+the \fBnocreateolddir\fR option. If \fImode\fR is not specified, \fB0755\fR is assumed.
 
 .TP
 \fBnocreateolddir\fR

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -92,6 +92,7 @@ TEST_CASES = \
 	test-0091.sh \
 	test-0092.sh \
 	test-0093.sh \
+	test-0094.sh \
 	test-0100.sh \
 	test-0101.sh \
 	test-0102.sh \

--- a/test/test-0094.sh
+++ b/test/test-0094.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+. ./test-common.sh
+
+# what is the default mode of a new old directory?
+cleanup 94
+
+# ------------------------------- Test 94 ------------------------------------
+preptest test.log 94 1 0
+rm -rf testdir
+
+$RLR test-config.94 --force 2>&1 | tee output.log
+
+if grep -q 'mode = 037777777777' output.log; then
+	echo "creating directory with mode -1 is not good"
+	exit 3
+fi

--- a/test/test-config.94.in
+++ b/test/test-config.94.in
@@ -1,0 +1,8 @@
+create
+
+&DIR&/test.log {
+    monthly
+    rotate 1
+    olddir &DIR&/testdir
+    createolddir
+}


### PR DESCRIPTION
File mode is optional for `create` and `olddircreate`, therefore old directory will be created with mode `037777777777` if not specified.