### PR TITLE
Demonstrate mode/UID/GID parsing ambiguity

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -92,6 +92,7 @@ TEST_CASES = \
 	test-0091.sh \
 	test-0092.sh \
 	test-0093.sh \
+	test-0095.sh \
 	test-0100.sh \
 	test-0101.sh \
 	test-0102.sh \

--- a/test/test-0095.sh
+++ b/test/test-0095.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+. ./test-common.sh
+
+# Does "create 1000 1001" mean "mode 01000, owner 1001", or "owner 1000, group 1001"?
+cleanup 95
+
+# ------------------------------- Test 95 ------------------------------------
+preptest test.log 95 1 0
+rm -rf testdir
+
+$RLR test-config.95 --force 2>&1 | tee output.log
+
+if ! grep -q 'uid = 1001' output.log; then
+	echo "\"create 1001 1002\" could mean numeric UID 1001 numeric GID 1002, maybe"
+	exit 3
+fi

--- a/test/test-config.95.in
+++ b/test/test-config.95.in
@@ -1,0 +1,5 @@
+&DIR&/test.log {
+    monthly
+    rotate 1
+    create 1001 1002
+}


### PR DESCRIPTION
Since we accept numeric UID/GID, we are never
really sure which of the three optional
numeric parameters to "create" or "createolddir"
is really given.

Tried to update manual page to say which
parameters and optional and in which order.