### PR TITLE
Stretch systemd timer over one hour

### DIFF
--- a/examples/logrotate.timer
+++ b/examples/logrotate.timer
@@ -4,7 +4,7 @@ Documentation=man:logrotate(8) man:logrotate.conf(5)
 
 [Timer]
 OnCalendar=daily
-AccuracySec=1h
+RandomizedDelaySec=1h
 Persistent=true
 
 [Install]


### PR DESCRIPTION
The initial introduction of the systemd timer in commit 05228c2f ("Add logrotate service and timer for systemd") included the directive `AccuracySec=12h`.  AccuracySec= is not a load distribution option but a power saving one, see systemd-timer(5).  In commit 3f3991ee ("Timer unit: change trigger fuzz from 12h to 1h") the value was reduced to 1h, while the discussion in #230 also mentioned load distribution.

Use RandomizedDelaySec= instead of AccuracySec= to actually spread the start time of the service, and ignore potential system wakeups below the rate of the default of AccuracySec= of one minute.

Fixes: #567