### PR TITLE
Rewrite readModeUidGid()

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -101,7 +101,8 @@ TEST_CASES = \
 	test-0106.sh \
 	test-0107.sh \
 	test-0108.sh \
-	test-0109.sh
+	test-0109.sh \
+	test-0110.sh
 
 EXTRA_DIST = \
 	compress \

--- a/test/test-0110.sh
+++ b/test/test-0110.sh
@@ -10,6 +10,7 @@ cleanup 110
 preptest test1.log 110 1
 preptest test2.log 110 1
 preptest test3.log 110 1
+preptest test4.log 110 1
 
 $RLR test-config.110 --force 2>&1 | tee output.log
 
@@ -25,5 +26,10 @@ fi
 
 if ! grep -qE 'test3.log mode = 0700 uid = [0-9]+ gid = [0-9]+' output.log; then
 	echo "\"create 0700\" should mean mode 0700"
+	exit 3
+fi
+
+if ! grep -q "error: test-config.110:22 unknown group 'bar baz'" output.log; then
+	echo "\"su 'foo bar'\" should mean user 'foo bar'"
 	exit 3
 fi

--- a/test/test-0110.sh
+++ b/test/test-0110.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+. ./test-common.sh
+
+cleanup 110
+
+# ------------------------------- Test 110 ------------------------------------
+# Does "create 1000 1001" mean "mode 01000, owner 1001", or "owner 1000, group 1001"?
+
+preptest test1.log 110 1
+preptest test2.log 110 1
+preptest test3.log 110 1
+
+$RLR test-config.110 --force 2>&1 | tee output.log
+
+if ! grep -qE 'test1.log mode = 0755 uid = 1 gid = 2' output.log; then
+	echo "\"create 0755 1001 1002\" should mean mode 0755 numeric UID 1001 numeric GID 1002"
+	exit 3
+fi
+
+if ! grep -qE 'test2.log mode = [0-9]+ uid = 1 gid = 2' output.log; then
+	echo "\"create 1001 1002\" should mean numeric UID 1001 numeric GID 1002"
+	exit 3
+fi
+
+if ! grep -qE 'test3.log mode = 0700 uid = [0-9]+ gid = [0-9]+' output.log; then
+	echo "\"create 0700\" should mean mode 0700"
+	exit 3
+fi

--- a/test/test-config.110.in
+++ b/test/test-config.110.in
@@ -1,0 +1,17 @@
+&DIR&/test1.log {
+    daily
+    rotate 1
+    create 0755 1 2
+}
+
+&DIR&/test2.log {
+    daily
+    rotate 1
+    create 1 2
+}
+
+&DIR&/test3.log {
+    daily
+    rotate 1
+    create 0700
+}

--- a/test/test-config.110.in
+++ b/test/test-config.110.in
@@ -15,3 +15,9 @@
     rotate 1
     create 0700
 }
+
+&DIR&/test4.log {
+    daily
+    rotate 1
+    su "foo bar" 'bar baz'
+}


### PR DESCRIPTION
Restore old behavior when one or two arguments are specified for the
create and createolddir directives.  This was broken with the
introduction of numeric uid/gid support.

Fixes: https://github.com/logrotate/logrotate/pull/561