### PR TITLE
logrotate.8: address mandoc lints

### DIFF
--- a/logrotate.8.in
+++ b/logrotate.8.in
@@ -10,7 +10,7 @@
 .  ns
 .  TP \\$1\" no doublequotes around argument!
 ..
-.\}
+
 .SH NAME
 
 logrotate \(hy rotates, compresses, and mails system logs
@@ -76,7 +76,8 @@ Tells \fBlogrotate\fR to use an alternate state file.  This is useful
 if \fBlogrotate\fR is being run as a different user for various sets of
 log files.  To prevent parallel execution \fBlogrotate\fR by default
 acquires a lock on the state file, if it cannot be acquired \fBlogrotate\fR
-will exit with value 3.  The default state file is \fI@STATE_FILE_PATH@\fR.
+will exit with value 3.
+The default state file is \fI@STATE_FILE_PATH@\fR.
 If \fI/dev/null\fR is given as the state file, then \fBlogrotate\fR will
 not try to lock or write the state file.
 


### PR DESCRIPTION
Fix the following two mandoc lints:

    mandoc: logrotate.8:13:2: ERROR: skipping unknown macro: .\}
    mandoc: logrotate.8:79:83: STYLE: input text line longer than 80 bytes: will exit with value...