### PR TITLE
test: quote user and group names

### DIFF
--- a/test/test-common.sh
+++ b/test/test-common.sh
@@ -95,7 +95,7 @@ genconfig() {
     user=$(id -u -n)
     group=$(id -g -n)
     rootgroup=$(id -g -n root)
-    sed "s,&DIR&,$PWD,g" < $input | sed "s,&USER&,$user,g" | sed "s,&GROUP&,$group,g" | sed "s,&ROOTGROUP&,$rootgroup,g" > $output
+    sed "s,&DIR&,$PWD,g" < $input | sed "s,&USER&,\"$user\",g" | sed "s,&GROUP&,\"$group\",g" | sed "s,&ROOTGROUP&,\"$rootgroup\",g" > $output
     chmod go-w $output
     config_crc=$(${MD5SUM} $output)
 }


### PR DESCRIPTION
Quote user and group names to avoid parsing failures on systems with spaces in the user or group name of the test user, e.g. CI systems.

Reported-by: alavrentiev