### PR TITLE
Correct size requirement for date format

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -1780,7 +1780,7 @@ static int prerotateSingleLog(const struct logInfo *log, unsigned logNum,
         while (*dext != '\0') {
             /* Will there be a space for a char and '\0'? */
             if (j >= (sizeof(dext_pattern) - 1) ||
-                i >= (sizeof(dformat) - 1)) {
+                i >= (sizeof(dformat) - 2)) {
                 message(MESS_ERROR, "Date format %s is too long\n",
                         log->dateformat);
                 return 1;


### PR DESCRIPTION
Within the loop two characters are written into the dformat buffer, iterated by i. Ensure space for two characters and the trailing NUL byte.

Reported-by: coverity