### PR TITLE
Do not hang on named pipe

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -104,7 +104,8 @@ TEST_CASES = \
 	test-0108.sh \
 	test-0109.sh \
 	test-0110.sh \
-	test-0111.sh
+	test-0111.sh \
+	test-0112.sh
 
 EXTRA_DIST = \
 	compress \

--- a/test/test-0112.sh
+++ b/test/test-0112.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+. ./test-common.sh
+
+cleanup 112
+
+# ------------------------------- Test 112 -------------------------------------
+# Do not hang on a named pipe (FIFO)
+
+preptest test_reg.log 112 2 1
+mkfifo test_fifo.log
+
+if [ ! -p test_fifo.log ]; then
+    echo "FIFO file test_fifo.log should exist"
+    exit 3
+fi
+
+$RLR --force test-config.112 2>error.log && exit 23
+
+checkoutput <<EOF
+test_reg.log 0
+test_reg.log.1.gz 1 zero
+test_reg.log.2.gz 1 first
+EOF
+
+grep "test_fifo.log.1 (read-only) for compression: Operation not supported" error.log >/dev/null
+if [ $? != 0 ]; then
+	echo "No error printed, but there should be one."
+	exit 3
+fi
+
+if [ ! -f test_fifo.log ]; then
+    echo "Regular file test_fifo.log should exist"
+    exit 3
+fi
+
+if [ ! -p test_fifo.log.1 ]; then
+    echo "FIFO file test_fifo.log.1 should exist"
+    exit 3
+fi

--- a/test/test-config.112.in
+++ b/test/test-config.112.in
@@ -1,0 +1,5 @@
+&DIR&/test*.log {
+    rotate 2
+    create
+    compress
+}


### PR DESCRIPTION
If a malicious application places a named pipe (FIFO) in a log directory do not hang while opening it.
Open the file in non blocking mode, and after checking it's a regular file drop the flag for portability.

Also specify the flag O_NOCTTY, since no log file should ever become the process's controlling terminal.