### PR TITLE
Adjust file limit

### DIFF
--- a/config.c
+++ b/config.c
@@ -770,7 +770,9 @@ static int readConfigPath(const char *path, struct logInfo *defConfig)
         }
         while ((dp = readdir(dirp)) != NULL) {
             if (checkFile(dp->d_name)) {
-                if (files_count >= UINT_MAX - REALLOC_STEP) {
+                /* Use a lower limit than `UINT_MAX - REALLOC_STEP` to please
+                 * GCC with LTO on 32 bit architectures. */
+                if (files_count >= UINT_MAX / 4) {
                     message(MESS_ERROR, "too many files in directory %s\n", path);
                     free_2d_array(namelist, files_count);
                     closedir(dirp);


### PR DESCRIPTION
The maximum number of files per directory is just a paranoid safety guard and probably one would even hit ENOMEM before. Adjust the limit a bit to avoid GCC stumbling on it when using LTO on 32-bit architectures:

    config.c:587:19: warning: iteration 1073741823 invokes undefined behavior [-Waggressive-loop-optimizations]
      587 |         free(array[i]);
          |                   ^
    config.c:586:19: note: within this loop
      586 |     for (i = 0; i < lines_count; ++i)
          |                   ^