### PR TITLE
test: wait for bash subprocesses

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -52,7 +52,7 @@ jobs:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
 
     - name: Install dependencies
-      run: brew install automake coreutils popt
+      run: brew install automake coreutils flock popt
 
     - name: Bootstrap
       run: ./autogen.sh

--- a/test/test-0087.sh
+++ b/test/test-0087.sh
@@ -11,11 +11,14 @@ touch state
 chmod 0640 state
 
 $RLR test-config.87 -f &
+process_id=$!
 
 sleep 2
 
 $RLR test-config.87
 ret=$?
+
+wait $process_id || exit $?
 
 if [ $ret -ne 3 ]; then
 	echo "Expected second instance to fail (returned $ret - expected 3)."

--- a/test/test-0092.sh
+++ b/test/test-0092.sh
@@ -10,8 +10,11 @@ preptest test.log 92 1
 touch state
 chmod 0644 state
 flock state -c "sleep 10" &
+process_id=$!
 
 $RLR -f test-config.92 || exit 23
+
+wait $process_id || exit $?
 
 checkoutput <<EOF
 test.log 0

--- a/test/test-0093.sh
+++ b/test/test-0093.sh
@@ -14,10 +14,11 @@ chmod 0640 state
 
 # run two instances of logrotate in parallel
 $RLR -f --wait-for-state-lock test-config.93 &
+process_id=$!
 sleep 1
 $RLR -f --wait-for-state-lock test-config.93
 EC2=$?
-wait || exit $?
+wait $process_id || exit $?
 [ $EC2 -eq 0 ] || exit $EC2
 
 checkoutput <<EOF


### PR DESCRIPTION
Avoid stray processes if testsuite runs very fast.