### PR TITLE
add support for rotation by minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # logrotate
 
-The logrotate utility is designed to simplify the administration of log files on a system which generates a lot of log files. Logrotate allows for the automatic rotation compression, removal and mailing of log files. Logrotate can be set to handle a log file hourly, daily, weekly, monthly or when the log file gets to a certain size.
+The logrotate utility is designed to simplify the administration of log files on a system which generates a lot of log files. Logrotate allows for the automatic rotation compression, removal and mailing of log files. Logrotate can be set to handle a log file hourly, daily, weekly, monthly, when time in minutes has elapsed or when the log file gets to a certain size.
 
 ## Download
 

--- a/logrotate.8.in
+++ b/logrotate.8.in
@@ -293,6 +293,11 @@ Log files are rotated the first time \fBlogrotate\fR is run in a month
 Log files are rotated if the current year is not the same as the last rotation.
 
 .TP
+\fBminutes \fIminutes\fR
+Log files are rotated the first time \fBlogrotate\fR is run after \fIminutes\fR
+have expired.
+
+.TP
 \fBsize \fIsize\fR
 Log files are rotated only if they grow bigger than \fIsize\fR bytes.  If
 \fIsize\fR is followed by \fIk\fR, the size is assumed to be in kilobytes.

--- a/logrotate.h
+++ b/logrotate.h
@@ -48,7 +48,8 @@ enum criterium {
     ROT_WEEKLY,
     ROT_MONTHLY,
     ROT_YEARLY,
-    ROT_SIZE
+    ROT_SIZE,
+    ROT_MINUTES
 };
 
 struct logInfo {
@@ -58,6 +59,7 @@ struct logInfo {
     char *oldDir;
     enum criterium criterium;
     unsigned weekday; /* used by ROT_WEEKLY only */
+    unsigned int minutes; /* used by ROT_MINUTES only */
     off_t threshold;
     off_t maxsize;
     off_t minsize;


### PR DESCRIPTION
Add support to specify the log rotation frequency in minutes. With this, logs are rotated at the first execution of logrotate after certain minutes have expired.