### PR TITLE
Fixup error handling

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -555,7 +555,7 @@ static int runScript(const struct logInfo *log, const char *logfn,
 
     if (pid == -1) {
         message(MESS_ERROR, "cannot fork: %s\n", strerror(errno));
-        return 1;
+        return -1;
     }
 
     if (pid == 0) {


### PR DESCRIPTION
Commit 6f06d90 ("Make wait() checks more reliable") changed the error detection of runScript() from != 0 to < 0.

Change the return value on a fork(2) failure from 1 to -1 to match the new error detection at call sites.