### PR TITLE
Add more dateformat specifiers

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [UNRELEASED]
 
 [UNRELEASED]: https://github.com/logrotate/logrotate/compare/3.22.0...main
+ - Add support for %G, %y, %g, %U, %W, %u, %w, and %j to dateformat. [ryancdotorg]
 
 ## [3.22.0] - 2024-06-01
  - fix calculations for time differences (#516)

--- a/logrotate.8.in
+++ b/logrotate.8.in
@@ -587,8 +587,8 @@ Do not archive old versions of log files with date extension
 .TP
 \fBdateformat\fR \fIformat_string\fR
 Specify the extension for \fBdateext\fR using the notation similar to
-\fBstrftime\fR(3) function.  Only %Y %m %d %H %M %S %V %s and %z specifiers are
-allowed.
+\fBstrftime\fR(3) function.  Only %Y %m %d %H %M %S %G %V %U %W %u %w %y %g %j
+%s and %z specifiers are allowed.
 The default value is \-%Y%m%d except hourly, which uses \-%Y%m%d%H as default
 value.  Note that also the character separating log name from the extension is
 part of the dateformat string.  The system clock must be set past Sep 9th 2001

--- a/logrotate.c
+++ b/logrotate.c
@@ -1818,19 +1818,42 @@ static int prerotateSingleLog(const struct logInfo *log, unsigned logNum,
             if (*dext == '%') {
                 switch (*(dext + 1)) {
                     case 'Y':
+                    case 'G':
                         strncat(dext_pattern, "[0-9][0-9]",
                                 sizeof(dext_pattern) - strlen(dext_pattern) - 1);
                         j += 10; /* strlen("[0-9][0-9]") */
                         /* FALLTHRU */
+                    case 'y':
+                    case 'g':
                     case 'm':
                     case 'd':
                     case 'H':
                     case 'M':
                     case 'S':
                     case 'V':
+                    case 'U':
+                    case 'W':
                         strncat(dext_pattern, "[0-9][0-9]",
                                 sizeof(dext_pattern) - strlen(dext_pattern) - 1);
                         j += 10;
+                        if (j >= (sizeof(dext_pattern) - 1)) {
+                            message(MESS_ERROR, "Date format %s is too long\n",
+                                    log->dateformat);
+                            return 1;
+                        }
+                        dformat[i++] = *(dext++);
+                        dformat[i] = *dext;
+                        break;
+                    case 'j':
+                        strncat(dext_pattern, "[0-9][0-9]",
+                                sizeof(dext_pattern) - strlen(dext_pattern) - 1);
+                        j += 10; /* strlen("[0-9][0-9]") */
+                        /* FALLTHRU */
+                    case 'u':
+                    case 'w':
+                        strncat(dext_pattern, "[0-9]",
+                                sizeof(dext_pattern) - strlen(dext_pattern) - 1);
+                        j += 5;
                         if (j >= (sizeof(dext_pattern) - 1)) {
                             message(MESS_ERROR, "Date format %s is too long\n",
                                     log->dateformat);

--- a/logrotate.c
+++ b/logrotate.c
@@ -1863,7 +1863,7 @@ static int prerotateSingleLog(const struct logInfo *log, unsigned logNum,
                         dformat[i] = *dext;
                         break;
                     case 's':
-                        /* End of year 2293 this pattern does not work. */
+                        /* End of year 2286 this pattern does not work. */
                         strncat(dext_pattern,
                                 "[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]",
                                 sizeof(dext_pattern) - strlen(dext_pattern) - 1);


### PR DESCRIPTION
Adds support for the following specifiers to `dateformat`:

* `%G` - ISO 8601 week-based year
* `%y` - two digit version of `%Y`
* `%g` -  two digit version of `%G`
* `%U` - week number variant
* `%W` - week number variant
* `%u` - day of week as 1 to 7, Monday being 1
* `%w` - day of week as 0 to 6, Sunday being 0
* `%j` -  day of year as 001 to 366

The two digit year variants break lexical sorting when year 2100 rolls around, but `%s` is already supported and has the same problem in the 23rd century. They're convenient for now, but if you don't want to leave this particular footgun around for our ancestors to find, I can remove them. If it's 2100 and you're reading this after your logs broke, you should have updated your config. 🤷