### PR TITLE
ci: drop Ubuntu 20.04

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         cc: [ gcc, clang ]
-        os: [ ubuntu-20.04, ubuntu-22.04, ubuntu-24.04 ]
+        os: [ ubuntu-22.04, ubuntu-24.04 ]
     runs-on: ${{ matrix.os }}
     env:
       CC: ${{ matrix.cc }}


### PR DESCRIPTION
Unsupported by 2025-04-15, see https://github.com/actions/runner-images/issues/11101