### PR TITLE
config:  use correct .v in default taboo list

### DIFF
--- a/config.c
+++ b/config.c
@@ -140,7 +140,7 @@ enum {
 };
 
 static const char *const defTabooExts[] = {
-    ",v",
+    ".v",
     ".bak",
     ".cfsaved",
     ".disabled",

--- a/logrotate.8.in
+++ b/logrotate.8.in
@@ -374,7 +374,7 @@ The current taboo extension list is changed (see the \fBinclude\fR directive
 for information on the taboo extensions).  If a + precedes the list of
 extensions, the current taboo extension list is augmented, otherwise it
 is replaced.  At startup, the taboo extension list
-.IR ,v ,
+.IR .v ,
 .IR .bak ,
 .IR .cfsaved ,
 .IR .disabled ,


### PR DESCRIPTION
In the default taboo ext array, the wildcard suffix `,v` in the configuration file should be spelled incorrectly,
The correct suffix should be `.v`, which is the suffix of the configuration file or backup file.

Additionally, update the description of `.v` in the man manual