### PR TITLE
Add check to verify that temp status file from previous logrotate run is present before attempting to delete it

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -2798,8 +2798,10 @@ static int writeState(const char *stateFilename)
     }
     strcpy(tmpFilename, stateFilename);
     strcat(tmpFilename, ".tmp");
-    /* Remove possible tmp state file from previous run */
-    error = unlink(tmpFilename);
+    /* If present, remove possible tmp state file from previous run */
+    if (access(tmpFilename, F_OK) == 0)
+        error = unlink(tmpFilename);
+
     if (error == -1 && errno != ENOENT) {
         message(MESS_ERROR, "error removing old temporary state file %s: %s\n",
                 tmpFilename, strerror(errno));


### PR DESCRIPTION

In environments where syscalls are tightly monitored, attempting to delete a file which is not present will result in an audit report of a failed syscall despite logrotate working as it should; this check simply aims to reduce auditing noise