### PR TITLE
Document initialization of last rotated time for state file entries 

### DIFF
--- a/logrotate.8.in
+++ b/logrotate.8.in
@@ -42,6 +42,12 @@ a log more than once in one day unless the criterion for that log is
 based on the log's size and \fBlogrotate\fR is being run more than once
 each day, or unless the \fB\-f\fR or \fB\-\-force\fR option is used.
 .P
+When a log file is encountered for the first time (that is, when it has
+no entry in the state file), \fBlogrotate\fR records the current time as
+the last rotation time.  As a result, time-based rotation criteria (such
+as \fBdaily\fR, \fBweekly\fR, or \fBmonthly\fR) may not be satisfied on
+that first run.
+.P
 Any number of config files may be given on the command line.  Later config
 files may override the options given in earlier files, so the order
 in which the \fBlogrotate\fR config files are listed is important.


### PR DESCRIPTION
Makes it clear in documentation that new log files that have time based rotation criteria are initialized to now when entered into the state file.

I had a situation where one day 0 I added a configuration for a daily rotated log file, and created said log file. Some logs were added to the file. My logrotate service runs just after midnight, so it ran on day 1. I expected my log file to be rotated on day 1, but I was surprised when it didn't, despite the state file claiming the last rotated time was day 1. After some debugging I guessed that this was a special case of the first time the log file being encountered by logrotate. Sure enough, on day 2 it was correctly rotated. I read the entire manual and did not see this behavior documented, but confirmed that this is what caused the issue by reading the source code. 

I think it would be nice if this behavior was documented (as it was unintuitive to me) so I propose this addition to the man pages. 