### PR TITLE
Update Differential ShellCheck workflow

### DIFF
--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -3,6 +3,7 @@
 name: Differential ShellCheck
 on:
   push:
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     permissions:
       security-events: write


### PR DESCRIPTION
Fixes issue discovered in #697: https://github.com/logrotate/logrotate/actions/runs/22671372866/job/65716075644?pr=697#step:4:15

```
fatal: Invalid revision range 1c00b347d2cd3b168c5dd5b7873a0a5de1b6e950..7a4306cbd76def71a6b92955a99a60657c5fe211
Warning:  Please check if the repository was cloned with `fetch-depth: 0`. Differential ShellCheck needs the entire history to work correctly.
```

Also update to the latest ubuntu runner.