### PR TITLE
fix for copying incompatible struct timespec from st_timepsec_t in AIX

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -841,16 +841,16 @@ static void setAtimeMtime(int fd, const char *filename, const struct stat *sb)
 #if defined HAVE_FUTIMENS && defined HAVE_STRUCT_STAT_ST_ATIM && defined HAVE_STRUCT_STAT_ST_MTIM
     struct timespec ts[2];
 
-    ts[0] = sb->st_atim;
-    ts[1] = sb->st_mtim;
+    memcpy( &ts[0], &sb->st_atim, sizeof(struct timespec) );
+    memcpy( &ts[1], &sb->st_mtim, sizeof(struct timespec) );
     futimens(fd, ts);
 
     (void)filename;
 #elif defined HAVE_UTIMENSAT && defined HAVE_STRUCT_STAT_ST_ATIM && defined HAVE_STRUCT_STAT_ST_MTIM
     struct timespec ts[2];
 
-    ts[0] = sb->st_atim;
-    ts[1] = sb->st_mtim;
+    memcpy( &ts[0], &sb->st_atim, sizeof(struct timespec) );
+    memcpy( &ts[1], &sb->st_mtim, sizeof(struct timespec) );
     utimensat(AT_FDCWD, filename, ts, AT_SYMLINK_NOFOLLOW);
 
     (void)fd;


### PR DESCRIPTION
#700 


Reason for fix:
In AIX, 
 since the structs(struct timespec ts and struct st_timespec_t st_atim, st_mtime) are same by layout, memcpy can be used instead of assignment operator for copying data between two structures solving the problem of incompatible types.