### PR TITLE
sparse: fix incorrect detection due to mismatched block size units

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [UNRELEASED]
 
+ - fix incorrect sparse file detection due to mismatched st_blocks and st_blksize units (#682)
+
 [UNRELEASED]: https://github.com/logrotate/logrotate/compare/3.22.0...main
  - Add support for %G, %y, %g, %U, %W, %u, %w, and %j to dateformat. [ryancdotorg]
 

--- a/logrotate.c
+++ b/logrotate.c
@@ -1178,10 +1178,9 @@ static int mailLogWrapper(const char *mailFilename, const char *mailComm,
    the file is a hole.  In that case, return true.  */
 static int is_probably_sparse(struct stat const *sb)
 {
-#if defined(HAVE_STRUCT_STAT_ST_BLOCKS) && defined(HAVE_STRUCT_STAT_ST_BLKSIZE)
+#if defined(HAVE_STRUCT_STAT_ST_BLOCKS)
     return (S_ISREG (sb->st_mode)
-            && sb->st_blksize != 0
-            && sb->st_blocks < sb->st_size / sb->st_blksize);
+            && sb->st_blocks < (sb->st_size + 512 - 1) / 512);
 #else
     return 0;
 #endif


### PR DESCRIPTION
## Summary
- Fix `is_probably_sparse()` function in `logrotate.c` that incorrectly compared `st_blocks` (512-byte units per POSIX) with `st_blksize` (filesystem preferred I/O size)
- When `st_blksize` differs from 512, sparse files on such filesystems could be incorrectly detected as non-sparse (or vice versa)
- This caused `copytruncate` to expand holes into actual data, wasting disk space
- Remove the now-unnecessary `HAVE_STRUCT_STAT_ST_BLKSIZE` preprocessor check and `st_blksize != 0` guard

Fixes #682