### PR TITLE
fix(copytruncate): do not skip copy when postrotate script exists

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -2377,7 +2377,7 @@ static int rotateSingleLog(const struct logInfo *log, unsigned logNum,
                 && !(log->flags & LOG_FLAG_TMPFILENAME)) {
             hasErrors = copyTruncate(log->files[logNum], rotNames->finalName,
                                      &state->sb, log,
-                                     !log->rotateCount && !log->logAddress);
+                                     !log->rotateCount && !log->logAddress && !log->post);
         }
 
 #ifdef WITH_ACL
@@ -2422,7 +2422,8 @@ static int postrotateSingleLog(const struct logInfo *log, unsigned logNum,
         int skipped_copy = (log->flags & (LOG_FLAG_COPYTRUNCATE | LOG_FLAG_COPY)) &&
                            !(log->flags & LOG_FLAG_TMPFILENAME) &&
                            !log->rotateCount &&
-                           !log->logAddress;
+                           !log->logAddress &&
+                           !log->post;
 
         if (!skipped_copy)
             hasErrors = compressLogFile(rotNames->finalName, log, &state->sb);


### PR DESCRIPTION
When rotate 0 is used with copytruncate, the copy step was skipped
unconditionally in rotateSingleLog(), causing postrotate scripts to
lose access to the log data before deletion.

This change preserves the copy when a postrotate script is defined
(log->post != NULL), since the script is likely to need the data
being rotated.

Also update the corresponding skipped_copy check in
postrotateSingleLog() for consistency.

Fixes: #667