### PR TITLE
fix: avoid unnecessary daily rotation shortly after maxsize rotation

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -1569,6 +1569,9 @@ static int findNeedRotating(const struct logInfo *log, unsigned logNum, int forc
                 state->doRotate = ((now.tm_mday != state->lastRotated.tm_mday) ||
                         (now.tm_mon != state->lastRotated.tm_mon) ||
                         (now.tm_year != state->lastRotated.tm_year));
+                if (state->doRotate
+                        && difftime(nowSecs, mktime(&state->lastRotated)) < DAY_SECONDS - 2 * 3600)
+                    state->doRotate = 0;
                 if (!state->doRotate) {
                     message(MESS_DEBUG, "  log does not need rotating "
                             "(log has been rotated at %d-%02d-%02d %02d:%02d, "


### PR DESCRIPTION
## Summary
- When using `daily` together with `maxsize`, logrotate may perform an unnecessary rotation at midnight even if maxsize triggered a rotation only minutes before.
- This happens because the `ROT_DAYS` check only compares calendar date fields (`tm_mday`, `tm_mon`, `tm_year`), not the actual elapsed time since the last rotation.
- Add a guard that prevents daily rotation if less than 22 hours have passed since the last rotation.

## Root cause
The `daily` rotation check in `findNeedRotating()` only checks if the calendar date changed:
```c
state->doRotate = ((now.tm_mday != state->lastRotated.tm_mday) ||
        (now.tm_mon != state->lastRotated.tm_mon) ||
        (now.tm_year != state->lastRotated.tm_year));
```

If `maxsize` triggers a rotation at 23:31, `lastRotated` is updated to that timestamp. At 00:01 the next day, `tm_mday` differs (e.g., 7 vs 8) even though only 30 minutes have passed, causing logrotate to rotate again unnecessarily.

## Fix
Added a minimum elapsed time guard using `difftime()` (same pattern used by the `ROT_MINUTES` case):
```c
if (state->doRotate
        && difftime(nowSecs, mktime(&state->lastRotated)) < DAY_SECONDS - 2 * 3600)
    state->doRotate = 0;
```

The 22-hour threshold handles DST transitions while preventing the redundant midnight rotation after a recent maxsize rotation.

Fixes #696