### PR TITLE
Escape glob metacharacters in filenames used for rotation bookkeeping

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -105,6 +105,32 @@ static int globerr(const char *pathname, int theerr)
     return 1;
 }
 
+/* Escape characters that glob(3)/fnmatch(3) treat as wildcard metacharacters
+ * ('*', '?', '[', ']') or as their own escape character ('\'). This is used
+ * when a literal, already-resolved path component (such as a log file's
+ * basename) is spliced into a pattern that is later passed to glob(), so
+ * that a literal metacharacter occurring in an actual filename is not
+ * reinterpreted as a wildcard and does not unintentionally match unrelated
+ * files. Returns a newly allocated string, or NULL on allocation failure. */
+static char *globEscape(const char *s)
+{
+    char *escaped = malloc(strlen(s) * 2 + 1);
+    char *o;
+
+    if (escaped == NULL)
+        return NULL;
+
+    o = escaped;
+    for (const char *i = s; *i != '\0'; i++) {
+        if (strchr("*?[]\\", *i) != NULL)
+            *o++ = '\\';
+        *o++ = *i;
+    }
+    *o = '\0';
+
+    return escaped;
+}
+
 /* We could switch to qsort_r to get rid of this global variable,
  * but qsort_r is not portable enough (Linux vs. *BSD vs ...)... */
 static struct compData _compData;
@@ -1659,16 +1685,31 @@ static int findLastRotated(const struct logNames *rotNames,
                            const char *fileext, const char *compext)
 {
     char *pattern;
+    char *escDir, *escBase;
     int glob_rc;
     glob_t globResult;
     size_t i;
     int last = 0;
     size_t prefixLen, suffixLen;
 
-    if (asprintf(&pattern, "%s/%s.*%s%s", rotNames->dirName,
-                 rotNames->baseName, fileext, compext) < 0)
+    escDir = globEscape(rotNames->dirName);
+    escBase = globEscape(rotNames->baseName);
+    if (escDir == NULL || escBase == NULL) {
+        free(escDir);
+        free(escBase);
         /* out of memory */
         return -1;
+    }
+
+    if (asprintf(&pattern, "%s/%s.*%s%s", escDir,
+                 escBase, fileext, compext) < 0) {
+        free(escDir);
+        free(escBase);
+        /* out of memory */
+        return -1;
+    }
+    free(escDir);
+    free(escBase);
 
     glob_rc = glob(pattern, 0, globerr, &globResult);
     free(pattern);
@@ -1999,8 +2040,19 @@ static int prerotateSingleLog(const struct logInfo *log, unsigned logNum,
             (log->flags & LOG_FLAG_DELAYCOMPRESS)) {
         if (log->flags & LOG_FLAG_DATEEXT) {
             /* glob for uncompressed files with our pattern */
-            if (asprintf(&glob_pattern, "%s/%s%s%s", rotNames->dirName,
-                         rotNames->baseName, dext_pattern, fileext) < 0) {
+            char *escDir = globEscape(rotNames->dirName);
+            char *escBase = globEscape(rotNames->baseName);
+            if (escDir == NULL || escBase == NULL) {
+                message_OOM();
+                free(escDir);
+                free(escBase);
+                return 1;
+            }
+            rc = asprintf(&glob_pattern, "%s/%s%s%s", escDir,
+                         escBase, dext_pattern, fileext);
+            free(escDir);
+            free(escBase);
+            if (rc < 0) {
                 message_OOM();
                 return 1;
             }
@@ -2050,8 +2102,19 @@ static int prerotateSingleLog(const struct logInfo *log, unsigned logNum,
     if (log->flags & LOG_FLAG_DATEEXT) {
         /* glob for compressed files with our pattern
          * and compress ext */
-        if (asprintf(&glob_pattern, "%s/%s%s%s%s", rotNames->dirName,
-                     rotNames->baseName, dext_pattern, fileext, compext) < 0) {
+        char *escDir = globEscape(rotNames->dirName);
+        char *escBase = globEscape(rotNames->baseName);
+        if (escDir == NULL || escBase == NULL) {
+            message_OOM();
+            free(escDir);
+            free(escBase);
+            return 1;
+        }
+        rc = asprintf(&glob_pattern, "%s/%s%s%s%s", escDir,
+                     escBase, dext_pattern, fileext, compext);
+        free(escDir);
+        free(escBase);
+        if (rc < 0) {
             message_OOM();
             return 1;
         }

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -106,7 +106,8 @@ TEST_CASES = \
 	test-0110.sh \
 	test-0111.sh \
 	test-0112.sh \
-	test-0113.sh
+	test-0113.sh \
+	test-0114.sh
 
 EXTRA_DIST = \
 	compress \

--- a/test/test-0114.sh
+++ b/test/test-0114.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+. ./test-common.sh
+
+cleanup 114
+
+# ------------------------------- Test 114 ------------------------------------
+# A literal '*' in a log file's name (e.g. an nginx access log for a wildcard
+# vhost, "*.example.com.access.log") must not be reinterpreted as a glob
+# wildcard when logrotate looks for that log's own previously rotated files.
+# Otherwise, rotating that log can corrupt the retention of unrelated logs
+# that merely happen to share a filename suffix.
+genconfig 114
+
+rm -f -- *.example.com.access.log*
+
+days_ago() {
+    n=$1
+    if date -v -1d > /dev/null 2>&1; then
+        date -v-${n}d "+%Y%m%d"
+    else
+        date "+%Y%m%d" --date "$n day ago"
+    fi
+}
+
+TODAY=$(/bin/date +%Y%m%d)
+
+# Two sibling logs, each with 5 days of pre-existing dateext rotations. A
+# correct "rotate 3" pass over each of them independently should reduce
+# that to 3 files: today's new rotation plus the 2 most recent old ones.
+for host in a b; do
+    echo live > "${host}.example.com.access.log"
+    for n in 5 4 3 2 1; do
+        echo old > "${host}.example.com.access.log-$(days_ago $n)"
+    done
+done
+
+# The wildcard-vhost log itself: only 2 days of pre-existing history, so its
+# own correct prune has nothing to remove.
+echo live > "*.example.com.access.log"
+for n in 2 1; do
+    echo old > "*.example.com.access.log-$(days_ago $n)"
+done
+
+$RLR test-config.114 --force || exit 23
+
+for host in a b; do
+    for n in 2 1; do
+        f="${host}.example.com.access.log-$(days_ago $n)"
+        if [ ! -f "$f" ]; then
+            echo "BUG: $f was removed -- rotating the '*' log corrupted" \
+                 "'${host}.example.com.access.log' retention" >&2
+            exit 2
+        fi
+    done
+    if [ ! -f "${host}.example.com.access.log-$TODAY" ]; then
+        echo "expected ${host}.example.com.access.log-$TODAY to exist" >&2
+        exit 2
+    fi
+done
+
+if [ ! -f "*.example.com.access.log-$TODAY" ]; then
+    echo "expected *.example.com.access.log-$TODAY to exist" >&2
+    exit 2
+fi

--- a/test/test-config.114.in
+++ b/test/test-config.114.in
@@ -1,0 +1,11 @@
+create
+
+"&DIR&/*.example.com.access.log" {
+    daily
+    dateext
+    dateformat -%Y%m%d
+    rotate 3
+    missingok
+    notifempty
+    nocompress
+}


### PR DESCRIPTION
## Problem

logrotate builds several internal glob(3) patterns from a log file's
*already-resolved* name, in order to find that log's own previously
rotated copies:

- `findLastRotated()` (classic numbered rotation)
- the delayed-compress lookup in `prerotateSingleLog()` (dateext mode)
- the excess-rotation pruning lookup in `prerotateSingleLog()` (dateext mode)

Each of these does roughly:

    asprintf(&pattern, "%s/%s<suffix>", rotNames->dirName, rotNames->baseName);
    glob(pattern, 0, globerr, &globResult);

`baseName` is the literal basename of the real file being rotated. If
that name itself contains a character glob(3)/fnmatch(3) treats as a
metacharacter -- most notably `*` -- it gets reinterpreted as a
wildcard instead of matched literally.

This is exactly what happens with nginx logs for wildcard server
names (`server_name *.example.com;`), where the resulting access log
can literally be named `*.example.com.access.log`. When logrotate
rotates that file, the pattern it builds to find "this log's old
rotations" ends up matching *any* file in the directory whose name
happens to end the right way (e.g. `other-vhost.example.com.access.log-20240101`),
because the leading `*` in the real filename is glob-interpreted
rather than literal.

The observable effect: retention becomes non-deterministic and
depends on what else happens to live in the log directory. Files can
be pruned as "excess" far earlier than their own `rotate` count says
they should be, because they get folded into a merged/miscounted
match set together with a completely unrelated log.

## Reproduction

With `a.example.com.access.log`, `b.example.com.access.log`, and the
literal `*.example.com.access.log` all rotated with `dateext` and
`rotate 3`: rotating the `*.example.com.access.log` entry's dateext
pruning pass matches and deletes recently-created rotated copies of
`a.` and `b.`'s logs, even though those logs had just correctly kept
exactly 3 copies moments earlier in the same run.

## Fix

Add a small `globEscape()` helper that backslash-escapes the
characters glob(3)/fnmatch(3) treat specially (`* ? [ ] \`), and use
it on `dirName`/`baseName` at the three call sites above, right
before they're spliced into a pattern that is passed to `glob()`.
This only affects pattern construction for these internal lookups --
every other use of `dirName`/`baseName` (building real paths for
`rename()`, `stat()`, removal, mail, etc.) is untouched and keeps
using the literal name.

## Testing

- `make check`: 107/107 existing tests pass, no regressions.
- Built and re-tested under `-fsanitize=address,undefined`; no new
  issues introduced (one pre-existing, unrelated leak inside popt's
  `poptGetNextOpt` is present identically on `main` before this
  change).
- Manually reproduced the bug against an unpatched build and
  confirmed the fix resolves it: after the fix, each log's rotated
  files are pruned independently and correctly, regardless of glob
  metacharacters in sibling filenames.
- Added `test/test-0114.sh` + `test/test-config.114.in` as a
  regression test in the existing suite. Verified it fails (exit 2,
  clear diagnostic) against an unpatched build and passes against
  the patched one; `make check` is 108/108 with it included.