### PR TITLE
Report the real popt error for a bad command line option

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -3355,7 +3355,7 @@ int main(int argc, const char **argv)
     if (arg < -1) {
         fprintf(stderr, "logrotate: bad argument %s: %s\n",
                 poptBadOption(optCon, POPT_BADOPTION_NOALIAS),
-                poptStrerror(rc));
+                poptStrerror(arg));
         poptFreeContext(optCon);
         return 2;
     }


### PR DESCRIPTION
main() passes 'rc' to poptStrerror() when reporting a bad command line option, but the popt error code is in 'arg'; 'rc' is still 0 at that point, so every command line error was reported as "unknown error":

    $ logrotate --bogus-option x
    logrotate: bad argument --bogus-option: unknown error
    $ logrotate --state
    logrotate: bad argument --state: unknown error

With the fix, popt's actual diagnostic is shown:

    logrotate: bad argument --bogus-option: unknown option
    logrotate: bad argument --state: missing argument